### PR TITLE
pause/unpause dispatch + fix null CI statuses

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -81,6 +81,12 @@ enum Commands {
         #[arg(long, default_value = "on-deck")]
         target: String,
     },
+    /// Pause or unpause dispatch (running jobs continue)
+    Pause {
+        /// Unpause instead of pause
+        #[arg(long)]
+        unpause: bool,
+    },
     /// Close a job
     Close {
         /// Job key
@@ -252,6 +258,26 @@ async fn main() -> Result<()> {
                 std::process::exit(1);
             }
             println!("Requeued {key}");
+        }
+
+        Commands::Pause { unpause } => {
+            let paused = !unpause;
+            let client = reqwest::Client::new();
+            let resp = client
+                .put(format!("{}/config/paused", cli.dispatcher_url))
+                .json(&serde_json::json!({ "paused": paused }))
+                .send()
+                .await?;
+            let body: serde_json::Value = resp.json().await?;
+            if let Some(err) = body.get("error") {
+                eprintln!("Error: {}", err.as_str().unwrap_or("unknown"));
+                std::process::exit(1);
+            }
+            if paused {
+                println!("Dispatch paused. Running jobs continue, no new work will be assigned.");
+            } else {
+                println!("Dispatch unpaused. Queued work will be assigned.");
+            }
         }
 
         Commands::Close { key, revoke } => {

--- a/crates/dispatcher/src/assignment.rs
+++ b/crates/dispatcher/src/assignment.rs
@@ -23,6 +23,10 @@ fn active_action_count(state: &DispatcherState) -> usize {
 
 /// Check if we have capacity to dispatch another action.
 pub async fn has_capacity(state: &DispatcherState) -> bool {
+    if state.paused.load(std::sync::atomic::Ordering::Relaxed) {
+        return false;
+    }
+
     let max = state
         .max_concurrent_actions
         .load(std::sync::atomic::Ordering::Relaxed);

--- a/crates/dispatcher/src/http.rs
+++ b/crates/dispatcher/src/http.rs
@@ -323,6 +323,7 @@ pub fn router(state: AppState) -> Router {
             "/config/max_concurrent_actions",
             put(set_max_concurrent_actions).get(get_max_concurrent_actions),
         )
+        .route("/config/paused", put(set_paused).get(get_paused))
         .route("/schema", get(get_schema))
         .route("/api.json", get(get_api_manifest));
 
@@ -662,6 +663,41 @@ async fn set_max_concurrent_actions(
     }
 
     Json(serde_json::json!({ "max_concurrent_actions": value, "previous": old })).into_response()
+}
+
+async fn get_paused(State(state): State<AppState>) -> impl IntoResponse {
+    let paused = state
+        .paused
+        .load(std::sync::atomic::Ordering::Relaxed);
+    Json(serde_json::json!({ "paused": paused }))
+}
+
+async fn set_paused(
+    State(state): State<AppState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let paused = match body.get("paused").and_then(|v| v.as_bool()) {
+        Some(v) => v,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "paused must be a boolean" })),
+            )
+                .into_response();
+        }
+    };
+
+    let was = state
+        .paused
+        .swap(paused, std::sync::atomic::Ordering::Relaxed);
+    info!(was, now = paused, "dispatch paused state updated");
+
+    // If unpausing, poke the assignment task to dispatch queued work
+    if was && !paused {
+        crate::assignment::request_dispatch(&state, crate::state::DispatchRequest::TryDispatchNext);
+    }
+
+    Json(serde_json::json!({ "paused": paused, "previous": was })).into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/dispatcher/src/state.rs
+++ b/crates/dispatcher/src/state.rs
@@ -183,6 +183,8 @@ pub struct DispatcherState {
     /// on release. Used for capacity checks instead of streaming KV keys
     /// (which can hang on tombstone-only buckets).
     pub active_claims: std::sync::atomic::AtomicUsize,
+    /// When true, no new jobs are dispatched. Running jobs continue.
+    pub paused: std::sync::atomic::AtomicBool,
     pub nats: NatsClient,
     pub kv: KvStores,
 
@@ -269,6 +271,7 @@ impl DispatcherState {
             config,
             max_concurrent_actions: std::sync::atomic::AtomicUsize::new(max_actions),
             active_claims: std::sync::atomic::AtomicUsize::new(0),
+            paused: std::sync::atomic::AtomicBool::new(false),
             nats: NatsClient::with_jetstream(client, js),
             kv,
             jobs: DashMap::new(),
@@ -292,6 +295,7 @@ impl DispatcherState {
             config,
             max_concurrent_actions: std::sync::atomic::AtomicUsize::new(max_actions),
             active_claims: std::sync::atomic::AtomicUsize::new(0),
+            paused: std::sync::atomic::AtomicBool::new(false),
             nats: NatsClient::with_prefix(client, js, prefix),
             kv,
             jobs: DashMap::new(),


### PR DESCRIPTION
- Add paused AtomicBool to DispatcherState, checked in has_capacity
- HTTP: GET/PUT /config/paused
- CLI: `chuggernaut pause` / `chuggernaut pause --unpause`
- Running jobs continue unaffected, only new dispatches are held
- Unpausing pokes TryDispatchNext to pick up queued work
- Fix: Forgejo combined status null statuses deserialization