### PR TITLE
Manual triage task + per-job timeout override (#31)

### DIFF
--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -125,6 +125,28 @@ pub fn parse_usage(stdout: &[u8]) -> Option<types::TokenUsage> {
     })
 }
 
+/// Pull the agent's final result text out of the CLI's `--output-format json`
+/// result object — its `result` field. Used to capture a **triage assessment**
+/// (spec §1.2), which runs without the channel MCP: there is no `submit_result`
+/// call, so the CLI's own JSON result on stdout is the only channel for the
+/// written output.
+///
+/// Same last-parseable-line scan as [`parse_usage`] — anything the container
+/// printed before the result object (clone, npm noise) is skipped. Returns
+/// `None` when stdout carries no result object or the result is empty.
+pub fn parse_result(stdout: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(stdout);
+    let value: serde_json::Value = text
+        .lines()
+        .rev()
+        .find_map(|line| serde_json::from_str(line.trim()).ok())?;
+    value
+        .get("result")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.trim().is_empty())
+}
+
 /// Claude CLI `--mcp-config` payload: `{"mcpServers": {name: {command, args, env}}}`.
 fn mcp_config_json(servers: &[McpServerConfig]) -> String {
     let map: serde_json::Map<String, serde_json::Value> = servers
@@ -252,6 +274,25 @@ mod tests {
             crate::transcript_path("da08d5f3-844e-430e-8363-39b4882f437b"),
             "/chuggernaut/claude/projects/-workspace/da08d5f3-844e-430e-8363-39b4882f437b.jsonl"
         );
+    }
+
+    #[test]
+    fn parses_result_text_for_triage() {
+        // A success result object carries the agent's prose in `result`.
+        let json = r#"{"type":"result","subtype":"success","is_error":false,"result":"The work task failed because the migration script referenced a dropped column. Recommend Revoke.","session_id":"x","usage":{"input_tokens":1,"output_tokens":2}}"#;
+        assert_eq!(
+            parse_result(json.as_bytes()).as_deref(),
+            Some(
+                "The work task failed because the migration script referenced a dropped column. Recommend Revoke."
+            )
+        );
+        // Past leading container noise.
+        let mut stdout = b"Cloning into '/workspace'...\n".to_vec();
+        stdout.extend_from_slice(json.as_bytes());
+        assert!(parse_result(&stdout).is_some());
+        // Empty / missing result → None, never an empty assessment.
+        assert!(parse_result(br#"{"type":"result","result":""}"#).is_none());
+        assert!(parse_result(b"plain output").is_none());
     }
 
     #[test]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -106,6 +106,10 @@ pub fn router(state: SharedState, ui_dist: Option<PathBuf>) -> axum::Router {
             "/api/v1/projects/{owner}/{project}/jobs/{seq}/revoke",
             post(routes::jobs_revoke),
         )
+        .route(
+            "/api/v1/projects/{owner}/{project}/jobs/{seq}/triage",
+            post(routes::jobs_triage),
+        )
         // Graph
         .route(
             "/api/v1/projects/{owner}/{project}/graph",

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -633,6 +633,24 @@ pub async fn jobs_revoke(
     .await
 }
 
+/// Dispatch an advisory triage agent over an Escalated/Stalled job (§1.2).
+/// Member+ like the other job mutations; the dispatcher enforces the state
+/// guard (409) and TRIAGE_IMAGE availability (422).
+pub async fn jobs_triage(
+    State(state): State<SharedState>,
+    Path((owner, project, seq)): Path<(String, String, u64)>,
+    Auth(identity): Auth,
+) -> ApiResult<Response> {
+    member_on(&identity, &owner, &project)?;
+    forward(
+        &state,
+        &store::subjects::jobs_triage(&owner, &project, seq),
+        serde_json::json!({}),
+        StatusCode::OK,
+    )
+    .await
+}
+
 // ── Graph ────────────────────────────────────────────────────────────────
 
 pub async fn graph_get(

--- a/crates/api/tests/config_settings.rs
+++ b/crates/api/tests/config_settings.rs
@@ -107,6 +107,7 @@ async fn config_endpoints() {
                 }],
                 agent_provider_default: "claude".into(),
                 agent_model_default: Some("claude-sonnet-5".into()),
+                triage_image: Some("registry.acme.com/triage:latest".into()),
                 repos_root: "/data/repos".into(),
                 repo_url_base: "ssh://git@host:2222".into(),
                 nats_url: "nats://localhost:4222".into(),
@@ -181,6 +182,7 @@ async fn config_endpoints() {
     assert_eq!(status, StatusCode::OK, "{pc}");
     assert_eq!(pc["dispatcher"]["nodes"][0]["name"], "local");
     assert_eq!(pc["dispatcher"]["agent_provider_default"], "claude");
+    assert_eq!(pc["dispatcher"]["triage_image"], "registry.acme.com/triage:latest");
     assert_eq!(pc["agent_secrets"], serde_json::json!(["ANTHROPIC_API_KEY"]));
     assert_eq!(pc["vapid_public"], false);
     assert!(

--- a/crates/dispatcher/src/config.rs
+++ b/crates/dispatcher/src/config.rs
@@ -32,6 +32,11 @@ pub struct DispatcherConfig {
     pub agent_provider_default: String,
     /// `AGENT_MODEL_DEFAULT` (optional, §12.4).
     pub agent_model_default: Option<String>,
+    /// `TRIAGE_IMAGE` — platform-level image for operator-dispatched triage
+    /// agents (spec §1.2). A platform default rather than the failing job's own
+    /// type image, so triage works uniformly on any job type (agent/command/
+    /// human). Unset → the triage action is unavailable (422).
+    pub triage_image: Option<String>,
     /// `DOCKER_NODES` — comma-separated `name|endpoint|slots` entries.
     /// Unset → single local-socket node with `DOCKER_SLOTS` slots (default 4).
     pub docker_nodes: Vec<DockerNodeConfig>,
@@ -90,6 +95,7 @@ impl DispatcherConfig {
             channel_binary: env_opt("CHANNEL_BINARY").map(PathBuf::from),
             agent_provider_default,
             agent_model_default: env_opt("AGENT_MODEL_DEFAULT"),
+            triage_image: env_opt("TRIAGE_IMAGE"),
             docker_nodes,
             hook_bin: env_opt("HOOK_BIN").map(PathBuf::from),
         })
@@ -152,6 +158,7 @@ impl DispatcherConfig {
             artifacts_identity: self.artifacts_identity().await?,
             agent_provider_default: Some(self.agent_provider_default.clone()),
             agent_model_default: self.agent_model_default.clone(),
+            triage_image: self.triage_image.clone(),
             nats_account_seed: self.nats_account_seed().await?,
             hook_bin: self.hook_bin.clone(),
         })

--- a/crates/dispatcher/src/core.rs
+++ b/crates/dispatcher/src/core.rs
@@ -80,6 +80,9 @@ pub struct CreateJobRequest {
     /// Additive per-job evaluators; validated (field rules + name collisions
     /// against the type's list) at release, not creation.
     pub eval: Vec<types::Evaluator>,
+    /// Optional per-job work-task timeout override (duration string, §1.1);
+    /// parseability validated at release. None → the type default applies.
+    pub timeout: Option<String>,
     pub factory: Option<String>,
 }
 
@@ -115,6 +118,10 @@ pub struct TaskExit {
     /// unparseable stdout, and on the restart re-attach path (where the monitor
     /// that would have parsed it no longer exists).
     pub usage: Option<TokenUsage>,
+    /// The agent CLI's final result text, harvested from stdout. Only carried
+    /// by triage runs (spec §1.2), which have no channel MCP and so report
+    /// their assessment through the CLI's JSON result rather than `submit_result`.
+    pub assessment: Option<String>,
 }
 
 impl TaskExit {
@@ -147,6 +154,14 @@ pub enum Msg {
         project: String,
         seq: u64,
         reply: Reply<Vec<u64>>,
+    },
+    /// `req.jobs.triage.*` (spec §1.2): dispatch an advisory triage agent over
+    /// an Escalated/Stalled job. Never changes job state.
+    TriageJob {
+        owner: String,
+        project: String,
+        seq: u64,
+        reply: Reply<()>,
     },
     SubmitResult {
         owner: String,
@@ -253,6 +268,11 @@ impl CoreHandle {
     pub async fn revoke_job(&self, owner: &str, project: &str, seq: u64) -> Result<Vec<u64>> {
         let (owner, project) = (owner.to_string(), project.to_string());
         self.call(|reply| Msg::RevokeJob { owner, project, seq, reply }).await
+    }
+
+    pub async fn triage_job(&self, owner: &str, project: &str, seq: u64) -> Result<()> {
+        let (owner, project) = (owner.to_string(), project.to_string());
+        self.call(|reply| Msg::TriageJob { owner, project, seq, reply }).await
     }
 
     pub async fn submit_result(
@@ -370,6 +390,9 @@ pub struct CoreConfig {
     pub agent_provider_default: Option<String>,
     /// §12.4 platform model default; job-type/evaluator `model:` overrides it.
     pub agent_model_default: Option<String>,
+    /// `TRIAGE_IMAGE` (§1.2): platform image for operator-dispatched triage
+    /// agents. None → the triage action is unavailable.
+    pub triage_image: Option<String>,
     /// Platform NATS account seed (`nats_account.seed`, §12.1) for minting
     /// per-container scoped credentials (§7.4). None → containers connect
     /// unauthenticated (tests, open dev NATS).
@@ -567,6 +590,9 @@ impl Core {
             Msg::RevokeJob { owner, project, seq, reply } => {
                 let _ = reply.send(self.revoke_job(&owner, &project, seq).await);
             }
+            Msg::TriageJob { owner, project, seq, reply } => {
+                let _ = reply.send(self.triage_job(&owner, &project, seq).await);
+            }
             Msg::SubmitResult { owner, project, seq, submission, reply } => {
                 let _ = reply.send(self.handle_submit_result(&owner, &project, seq, submission).await);
             }
@@ -646,6 +672,7 @@ impl Core {
             base_ref: None,
             knowledge_tags: req.knowledge_tags,
             eval: req.eval,
+            timeout: req.timeout,
             factory: req.factory,
             created_at: Utc::now(),
             ready_at: None,

--- a/crates/dispatcher/src/eval.rs
+++ b/crates/dispatcher/src/eval.rs
@@ -170,10 +170,13 @@ impl Core {
         }
 
         // Eval containers get vars but only the evaluator's own secrets (§4.1).
+        // Evaluators keep the job type's timeout — the per-job `Job.timeout`
+        // override is Work-scoped only (§1.1, §3.5).
+        let eval_timeout = task_timeout(&job_type);
         let env = self
             .container_env(
                 owner, project, seq, branch, &job_type, &evaluator.secrets,
-                ChannelRole::Eval { task_id },
+                ChannelRole::Eval { task_id }, eval_timeout,
             )
             .await?;
         let tx = self.self_tx.clone().expect("spawned core");
@@ -188,7 +191,7 @@ impl Core {
                     env,
                     files: self
                         .ssh_credential_files(
-                            owner, project, seq, ChannelRole::Eval { task_id }, &job_type,
+                            owner, project, seq, ChannelRole::Eval { task_id }, eval_timeout,
                         )
                         .await?,
                     cpu_limit: job_type.resources.as_ref().and_then(|r| r.cpu),
@@ -213,7 +216,7 @@ impl Core {
                     let _ = tx
                         .send(Msg::TaskExited {
                             owner: o, project: p, seq, task_id,
-                            exit: TaskExit { exit_code, eval_json, usage: None },
+                            exit: TaskExit { exit_code, eval_json, usage: None, assessment: None },
                         })
                         .await;
                 });
@@ -234,7 +237,7 @@ impl Core {
                 let (mcp_servers, mut files) = self.channel_mcp(&env);
                 files.extend(
                     self.ssh_credential_files(
-                        owner, project, seq, ChannelRole::Eval { task_id }, &job_type,
+                        owner, project, seq, ChannelRole::Eval { task_id }, eval_timeout,
                     )
                     .await?,
                 );
@@ -270,7 +273,7 @@ impl Core {
                     let _ = tx
                         .send(Msg::TaskExited {
                             owner: o, project: p, seq, task_id,
-                            exit: TaskExit { exit_code, eval_json: None, usage },
+                            exit: TaskExit { exit_code, eval_json: None, usage, assessment: None },
                         })
                         .await;
                 });
@@ -357,7 +360,7 @@ impl Core {
         mut task: Task,
         exit: TaskExit,
     ) -> Result<()> {
-        let TaskExit { exit_code, eval_json, usage } = exit;
+        let TaskExit { exit_code, eval_json, usage, .. } = exit;
         let key = (owner.to_string(), project.to_string(), seq);
         let Some(slot_idx) = self
             .active

--- a/crates/dispatcher/src/exec.rs
+++ b/crates/dispatcher/src/exec.rs
@@ -33,6 +33,18 @@ pub struct ExecState {
     /// §4.3 context for the current cycle's work task.
     pub eval_context: Vec<EvalResult>,
     pub merge_conflict: Option<String>,
+    /// Per-job work-task timeout override (`Job.timeout`, §1.1), resolved once
+    /// at Work entry. Applies to Work-phase tasks only — evaluators keep the
+    /// type default. None → the type's `resources.task_timeout` applies.
+    pub work_timeout: Option<Duration>,
+}
+
+impl ExecState {
+    /// The timeout governing this job's Work-phase tasks: the per-job override
+    /// if set, else the job type's `resources.task_timeout` (§1.1, §3.5).
+    pub(crate) fn work_timeout(&self) -> Duration {
+        self.work_timeout.unwrap_or_else(|| task_timeout(&self.job_type))
+    }
 }
 
 impl Core {
@@ -115,6 +127,10 @@ impl Core {
                 .await?;
         }
 
+        // §1.1 per-job override: parseability is validated at release, so a
+        // malformed string here is a stale record — fall back to the type
+        // default rather than failing the launch.
+        let work_timeout = job.timeout.as_deref().and_then(|s| parse_duration(s).ok());
         self.active.insert(
             (owner.to_string(), project.to_string(), seq),
             ExecState {
@@ -130,6 +146,7 @@ impl Core {
                 gate: None,
                 eval_context,
                 merge_conflict,
+                work_timeout,
             },
         );
         self.launch_work_task(owner, project, seq, cycle, 1).await
@@ -147,6 +164,10 @@ impl Core {
         let key = (owner.to_string(), project.to_string(), seq);
         let exec = self.active.get(&key).expect("exec state");
         let job_type = exec.job_type.clone();
+        // §1.1 per-job override for Work-phase tasks (else type default). Drives
+        // the agent run timeout and the §7.4 credential TTLs so creds outlive a
+        // longer override.
+        let work_timeout = exec.work_timeout();
         let (eval_context, merge_conflict) = (exec.eval_context.clone(), exec.merge_conflict.clone());
         let job = self.must_get(owner, project, seq)?.clone();
         let base_ref = job.base_ref.clone().expect("base_ref set in Work");
@@ -216,7 +237,7 @@ impl Core {
         let env = self
             .container_env(
                 owner, project, seq, &job.branch, &job_type, &job_type.work.secrets,
-                ChannelRole::Work,
+                ChannelRole::Work, work_timeout,
             )
             .await?;
         match job_type.work.r#type {
@@ -230,7 +251,7 @@ impl Core {
                     .await?;
                 let (mcp_servers, mut files) = self.channel_mcp(&env);
                 files.extend(
-                    self.ssh_credential_files(owner, project, seq, ChannelRole::Work, &job_type)
+                    self.ssh_credential_files(owner, project, seq, ChannelRole::Work, work_timeout)
                         .await?,
                 );
                 let config = AgentRunConfig {
@@ -249,7 +270,7 @@ impl Core {
                     mcp_servers,
                     files,
                     env,
-                    task_timeout: task_timeout(&job_type),
+                    task_timeout: work_timeout,
                     eval_context,
                     merge_conflict,
                     session_id: session_id.clone().unwrap_or_default(),
@@ -275,7 +296,7 @@ impl Core {
                     let _ = tx
                         .send(Msg::TaskExited {
                             owner: o, project: p, seq, task_id,
-                            exit: TaskExit { exit_code, eval_json: None, usage },
+                            exit: TaskExit { exit_code, eval_json: None, usage, assessment: None },
                         })
                         .await;
                 });
@@ -287,7 +308,7 @@ impl Core {
                     cmd: bootstrap_cmd(&["sh".into(), "-c".into(), run]),
                     env,
                     files: self
-                        .ssh_credential_files(owner, project, seq, ChannelRole::Work, &job_type)
+                        .ssh_credential_files(owner, project, seq, ChannelRole::Work, work_timeout)
                         .await?,
                     cpu_limit: job_type.resources.as_ref().and_then(|r| r.cpu),
                     memory_limit: job_type.resources.as_ref().and_then(|r| r.memory.clone()),
@@ -353,6 +374,13 @@ impl Core {
             }
             TaskPhase::MergeGate => {
                 self.on_gate_exited(owner, project, seq, task, exit.exit_code, exit.eval_json).await
+            }
+            // Advisory triage (§1.2): record the assessment; never touch job state.
+            TaskPhase::Triage => {
+                if task.state != TaskState::Running {
+                    return Ok(());
+                }
+                self.on_triage_exited(owner, project, seq, task, exit).await
             }
         }
     }
@@ -724,6 +752,7 @@ impl Core {
             gate: None,
             eval_context: vec![],
             merge_conflict: None,
+            work_timeout: job.timeout.as_deref().and_then(|s| parse_duration(s).ok()),
         });
         Ok(())
     }
@@ -761,6 +790,10 @@ impl Core {
         job_type: &JobType,
         secrets_declared: &[String],
         role: ChannelRole,
+        // §7.4 credential TTL: the resolved timeout of the task these creds
+        // serve (work override or type default), so a longer-running task's
+        // credentials outlive it.
+        creds_ttl: Duration,
     ) -> Result<HashMap<String, String>> {
         let mut env = HashMap::from([
             ("JOB_ID".into(), seq.to_string()),
@@ -779,21 +812,7 @@ impl Core {
                 env.insert("JOB_TASK_ID".into(), task_id.to_string());
             }
         }
-        // §5.2: repos behind the SSH front need the injected cert (paths are
-        // fixed — the credential itself rides in via ssh_credential_files).
-        // No SendEnv needed for git protocol v2 — git appends
-        // `-o SendEnv=GIT_PROTOCOL` itself once it detects an OpenSSH variant.
-        // The server half (`AcceptEnv GIT_PROTOCOL`) is sshd's config.
-        if self.ssh_front_active() {
-            env.insert(
-                "GIT_SSH_COMMAND".into(),
-                format!(
-                    "ssh -i {SSH_ID_PATH} -o CertificateFile={SSH_CERT_PATH} \
-                     -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
-                     -o UserKnownHostsFile=/dev/null"
-                ),
-            );
-        }
+        self.inject_git_ssh_command(&mut env);
         // §7.4: scoped credentials valid for task_timeout, minted per launch.
         if let Some(seed) = &self.config.nats_account_seed {
             let signer = auth::nats::NatsUserSigner::from_account_seed(seed)
@@ -804,7 +823,7 @@ impl Core {
                     auth::nats::eval_container_permissions(owner, project, seq, task_id)
                 }
             };
-            let ttl = chrono::Duration::from_std(task_timeout(job_type))
+            let ttl = chrono::Duration::from_std(creds_ttl)
                 .unwrap_or_else(|_| chrono::Duration::hours(1));
             let creds = signer
                 .mint_creds(
@@ -931,8 +950,26 @@ impl Core {
         Ok(())
     }
 
-    fn ssh_front_active(&self) -> bool {
+    pub(crate) fn ssh_front_active(&self) -> bool {
         self.config.ssh_ca.is_some() && self.config.repo_url_base.starts_with("ssh://")
+    }
+
+    /// §5.2: repos behind the SSH front need the injected cert (paths are fixed
+    /// — the credential itself rides in via `ssh_credential_files`). No SendEnv
+    /// needed for git protocol v2 — git appends `-o SendEnv=GIT_PROTOCOL` itself
+    /// once it detects an OpenSSH variant (the server half `AcceptEnv
+    /// GIT_PROTOCOL` is sshd's config). No-op when the SSH front is inactive.
+    pub(crate) fn inject_git_ssh_command(&self, env: &mut HashMap<String, String>) {
+        if self.ssh_front_active() {
+            env.insert(
+                "GIT_SSH_COMMAND".into(),
+                format!(
+                    "ssh -i {SSH_ID_PATH} -o CertificateFile={SSH_CERT_PATH} \
+                     -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+                     -o UserKnownHostsFile=/dev/null"
+                ),
+            );
+        }
     }
 
     /// §7.4 per-job SSH credential as injected files (work rw, eval ro).
@@ -943,7 +980,9 @@ impl Core {
         project: &str,
         seq: u64,
         role: ChannelRole,
-        job_type: &JobType,
+        // §7.4 credential TTL: the resolved timeout of the task these creds
+        // serve (work override or type default).
+        creds_ttl: Duration,
     ) -> Result<Vec<container::InjectedFile>> {
         if !self.ssh_front_active() {
             return Ok(vec![]);
@@ -953,7 +992,7 @@ impl Core {
             ChannelRole::Work => auth::ssh::CertAccess::ReadWrite,
             ChannelRole::Eval { .. } => auth::ssh::CertAccess::ReadOnly,
         };
-        let ttl = chrono::Duration::from_std(task_timeout(job_type))
+        let ttl = chrono::Duration::from_std(creds_ttl)
             .unwrap_or_else(|_| chrono::Duration::hours(1));
         let cred = ca
             .issue_job_credential(owner, project, seq, access, ttl)

--- a/crates/dispatcher/src/graph.rs
+++ b/crates/dispatcher/src/graph.rs
@@ -119,6 +119,7 @@ mod tests {
             base_ref: None,
             knowledge_tags: vec![],
             eval: vec![],
+            timeout: None,
             factory: None,
             created_at: Utc::now(),
             ready_at: None,

--- a/crates/dispatcher/src/handlers.rs
+++ b/crates/dispatcher/src/handlers.rs
@@ -156,6 +156,11 @@ struct CreateJobBody {
     /// Additive per-job evaluators (design-lifecycle.md); validated at release.
     #[serde(default)]
     eval: Vec<types::Evaluator>,
+    /// Optional per-job work-task timeout override (duration string, §1.1);
+    /// layers over the type's `resources.task_timeout` for Work tasks only.
+    /// Parseability validated at release. Absent → the type default applies.
+    #[serde(default)]
+    timeout: Option<String>,
 }
 
 /// Wire body for `req.tasks.resolve`: the §6.2 `TaskResolution` plus the
@@ -366,6 +371,7 @@ async fn spawn_read_handlers(
                             deps: b.deps,
                             knowledge_tags: b.knowledge_tags,
                             eval: b.eval,
+                            timeout: b.timeout,
                             factory: None,
                         };
                         match jobs_handle.create_job(create).await {
@@ -389,6 +395,13 @@ async fn spawn_read_handlers(
                     }
                 }
                 ("revoke", Some(seq)) => match jobs_handle.revoke_job(owner, project, seq).await {
+                    Err(e) => error_reply(&e),
+                    Ok(_) => fetch_job(&jobs_store, owner, project, seq).await,
+                },
+                // Operator-dispatched advisory triage (§1.2): launches a triage
+                // agent over the job state; never changes job state. Reply is
+                // the job as-is (unchanged), like revoke's re-fetch.
+                ("triage", Some(seq)) => match jobs_handle.triage_job(owner, project, seq).await {
                     Err(e) => error_reply(&e),
                     Ok(_) => fetch_job(&jobs_store, owner, project, seq).await,
                 },
@@ -924,6 +937,7 @@ mod tests {
             base_ref: None,
             knowledge_tags: vec![],
             eval: vec![],
+            timeout: None,
             factory: None,
             created_at: Utc::now(),
             ready_at: None,

--- a/crates/dispatcher/src/harvest.rs
+++ b/crates/dispatcher/src/harvest.rs
@@ -47,8 +47,24 @@ impl Harvester {
         task_id: u64,
         out: &AgentOutput,
     ) -> Option<TokenUsage> {
+        self.collect_agent(owner, project, seq, task_id, out).await.1
+    }
+
+    /// Full agent-run collection: stores stdout + transcript and returns both
+    /// the CLI's final **result text** and measured token usage. Work and eval
+    /// runs only need the usage (via [`collect`]); triage (spec §1.2) also needs
+    /// the result text — it runs without the channel MCP, so the CLI's own JSON
+    /// result on stdout is the only channel for the assessment.
+    pub(crate) async fn collect_agent(
+        &self,
+        owner: &str,
+        project: &str,
+        seq: u64,
+        task_id: u64,
+        out: &AgentOutput,
+    ) -> (Option<String>, Option<TokenUsage>) {
         let Some(id) = &out.container_id else {
-            return None; // provider without a container (fakes, stubs)
+            return (None, None); // provider without a container (fakes, stubs)
         };
 
         let logs = match self.backend.logs(id).await {
@@ -59,13 +75,14 @@ impl Harvester {
             }
         };
 
-        // Usage comes from the logs, not the transcript: the CLI's JSON result
-        // is a documented interface, while the transcript format is internal
-        // and version-unstable.
+        // Both come from the logs, not the transcript: the CLI's JSON result is
+        // a documented interface, while the transcript format is internal and
+        // version-unstable.
         let usage = logs.as_deref().and_then(agent::claude::parse_usage);
         if usage.is_none() {
             tracing::debug!("job {seq} task {task_id}: no usage in agent stdout");
         }
+        let result = logs.as_deref().and_then(agent::claude::parse_result);
 
         if let Some(bytes) = logs {
             self.store(owner, project, seq, task_id, ArtifactKind::Stdout, &bytes)
@@ -96,7 +113,7 @@ impl Harvester {
                 Err(e) => tracing::warn!("job {seq} task {task_id}: transcript copy failed: {e}"),
             }
         }
-        usage
+        (result, usage)
     }
 
     /// Collect just the logs, for a container the dispatcher launched itself

--- a/crates/dispatcher/src/lib.rs
+++ b/crates/dispatcher/src/lib.rs
@@ -25,3 +25,4 @@ pub mod run;
 pub mod scan;
 pub mod seed;
 pub mod state;
+pub mod triage;

--- a/crates/dispatcher/src/reconcile.rs
+++ b/crates/dispatcher/src/reconcile.rs
@@ -199,7 +199,7 @@ impl Core {
                                 owner: o, project: p, seq, task_id,
                                 // Re-attaching after a restart: the agent
                                 // monitor that would have parsed usage is gone.
-                                exit: TaskExit { exit_code, eval_json, usage: None },
+                                exit: TaskExit { exit_code, eval_json, usage: None, assessment: None },
                             })
                             .await;
                     });
@@ -253,14 +253,16 @@ pub(crate) fn result_pass(result: &TaskResult) -> bool {
         TaskResult::Command { pass, .. }
         | TaskResult::Agent { pass, .. }
         | TaskResult::Human { pass, .. } => *pass,
-        TaskResult::Work { .. } => true,
+        // Triage is advisory (§1.2) — never an eval verdict, so this is never
+        // consulted; treat it as a non-failure for completeness.
+        TaskResult::Work { .. } | TaskResult::Triage { .. } => true,
     }
 }
 
 pub(crate) fn result_abort(result: &TaskResult) -> bool {
     match result {
         TaskResult::Agent { abort, .. } | TaskResult::Human { abort, .. } => *abort,
-        TaskResult::Command { .. } | TaskResult::Work { .. } => false,
+        TaskResult::Command { .. } | TaskResult::Work { .. } | TaskResult::Triage { .. } => false,
     }
 }
 
@@ -270,5 +272,7 @@ pub(crate) fn result_structured(result: &TaskResult) -> Option<serde_json::Value
         | TaskResult::Agent { structured, .. }
         | TaskResult::Human { structured, .. }
         | TaskResult::Work { structured, .. } => structured.clone(),
+        // Triage carries prose, not structured findings.
+        TaskResult::Triage { .. } => None,
     }
 }

--- a/crates/dispatcher/src/release.rs
+++ b/crates/dispatcher/src/release.rs
@@ -183,6 +183,15 @@ pub async fn static_errors(
     let mut errs = Vec::new();
     let mut require_file = Vec::new();
 
+    // §1.1 per-job timeout override: parseability validated at release (the
+    // string is on the Job, not pinned to a ref), consistent with "wiring
+    // validated at release, not creation".
+    if let Some(t) = &job.timeout
+        && let Err(e) = types::parse_duration(t)
+    {
+        errs.push(ValidationError::new(seq, "timeout", e.to_string()));
+    }
+
     if job_type.work.r#type == WorkType::Agent {
         if let Some(p) = &job_type.work.prompt {
             require_file.push(("work.prompt".to_string(), p.clone()));

--- a/crates/dispatcher/src/run.rs
+++ b/crates/dispatcher/src/run.rs
@@ -84,6 +84,7 @@ async fn publish_config_snapshot(store: &NatsStore, config: &DispatcherConfig, s
             .collect(),
         agent_provider_default: config.agent_provider_default.clone(),
         agent_model_default: config.agent_model_default.clone(),
+        triage_image: config.triage_image.clone(),
         repos_root: config.repos_root.display().to_string(),
         repo_url_base: config.repo_url_base.clone(),
         nats_url: config.nats_url.clone(),

--- a/crates/dispatcher/src/scan.rs
+++ b/crates/dispatcher/src/scan.rs
@@ -6,7 +6,7 @@ use crate::core::{Core, Result, TaskExit};
 use crate::exec::task_timeout;
 use crate::release;
 use chrono::Utc;
-use types::{JobState, TaskKind, TaskResult, TaskState, parse_duration};
+use types::{JobState, TaskKind, TaskPhase, TaskResult, TaskState, parse_duration};
 
 /// Prompt marker identifying deadline escalation tasks — the one-shot rule
 /// (§3.5) excludes jobs whose task log contains a *resolved* one.
@@ -25,17 +25,23 @@ impl Core {
         let keys: Vec<(String, String, u64)> = self.active.keys().cloned().collect();
         let now = Utc::now();
         for (owner, project, seq) in keys {
-            let timeout = self
+            // The per-job override is Work-scoped (§1.1, §3.5): Work-phase tasks
+            // use it, every other phase uses the type default. Enforcing the
+            // split here — at kill time — is what keeps the override work-scoped.
+            let (work_timeout, type_timeout) = match self
                 .active
                 .get(&(owner.clone(), project.clone(), seq))
-                .map(|e| task_timeout(&e.job_type));
-            let Some(timeout) = timeout else { continue };
+            {
+                Some(e) => (e.work_timeout(), task_timeout(&e.job_type)),
+                None => continue,
+            };
             let expired: Vec<_> = self
                 .tasks
                 .list_for_job(&owner, &project, seq)
                 .await?
                 .into_iter()
                 .filter(|t| {
+                    let timeout = if t.phase == TaskPhase::Work { work_timeout } else { type_timeout };
                     t.state == TaskState::Running
                         && !matches!(t.kind, TaskKind::Human { .. })
                         && t.started_at
@@ -43,6 +49,8 @@ impl Core {
                 })
                 .collect();
             for task in expired {
+                let timeout =
+                    if task.phase == TaskPhase::Work { work_timeout } else { type_timeout };
                 tracing::warn!("task {}#{} timed out after {timeout:?}", seq, task.id);
                 if let Some(cid) = &task.container_id {
                     let _ = self.backend.kill(cid).await;

--- a/crates/dispatcher/src/triage.rs
+++ b/crates/dispatcher/src/triage.rs
@@ -1,0 +1,343 @@
+//! Operator-dispatched triage (spec §1.2): an advisory agent run over a job's
+//! full state that produces a written assessment + recommendation, recorded as
+//! a `TaskPhase::Triage` task in the job.
+//!
+//! **Purely advisory** — triage never drives a job transition (no `state.rs`
+//! change): the operator still decides Retry / Resolve / Revoke. It is available
+//! only while the job is Escalated or Stalled, and may be repeated. The triage
+//! agent runs in a platform-level image (`TRIAGE_IMAGE`) so it works uniformly
+//! on any job type — agent, command, or human. The prompt embeds the job state
+//! the dispatcher already holds (brief, escalation reason, every task's result,
+//! and captured stdout logs); there is no channel MCP, so the assessment is
+//! read back from the CLI's own JSON result on stdout ([`agent::claude::parse_result`]).
+
+use crate::core::{Core, CoreError, Msg, Result, TaskExit};
+use crate::exec::{ChannelRole, job_brief_block, provider_name};
+use crate::release::ValidationError;
+use agent::AgentRunConfig;
+use chrono::Utc;
+use std::collections::HashMap;
+use std::time::Duration;
+use store::ArtifactKind;
+use types::{Job, JobState, Task, TaskKind, TaskPhase, TaskResult, TaskState};
+
+/// Wall-clock budget for a triage run. Triage reads and reasons over the job
+/// state; it is not the fallible product work, so a fixed, generous bound is
+/// enough. Enforced by the provider (it kills the container on elapse).
+const TRIAGE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// How much of each captured stdout log to embed in the prompt — the tail,
+/// which is where a failure's error output lands. Keeps the prompt bounded when
+/// a job accumulated many verbose tasks.
+const STDOUT_TAIL_BYTES: usize = 4_000;
+
+/// The built-in triage instruction prompt, prepended to the assembled job-state
+/// context. Platform-owned (not repo-versioned): triage is a platform
+/// capability, not a per-project contract.
+pub(crate) const TRIAGE_PROMPT: &str = "\
+You are a triage agent for the Chuggernaut job orchestrator. A job has landed in \
+an operator-intervention state (Escalated or Stalled) and a human operator has \
+asked for help understanding what went wrong.
+
+Below is the complete state of the job: its brief, why it stopped, every task \
+that ran with its result, and the captured stdout of those tasks. The project \
+repository has been cloned into your working directory as further context. You \
+cannot act on the job or change its state — you are purely advisory.
+
+Produce a concise written assessment with three parts:
+1. What happened — the most likely root cause of the failure, grounded in the \
+evidence below.
+2. Recommendation — whether the operator should Retry, Resolve (submit the \
+current branch for evaluation), or Revoke, and why. If the job is Stalled there \
+is no work to submit, so only Retry or Revoke apply.
+3. Caveats — anything you could not determine from the available evidence.
+
+Write for a human operator who will make the final call. Do not attempt to use \
+any tools to change the job; your final message is the assessment.
+
+---
+";
+
+impl Core {
+    /// Handle `req.jobs.triage.*` (spec §1.2): launch an advisory triage agent
+    /// over the job. Guards on Escalated/Stalled and a configured `TRIAGE_IMAGE`;
+    /// creates a `TaskPhase::Triage` task and spawns the run. Never changes job
+    /// state, so it is not routed through `set_state`/`assert_transition`.
+    pub async fn triage_job(&mut self, owner: &str, project: &str, seq: u64) -> Result<()> {
+        let job = self.must_get(owner, project, seq)?.clone();
+        // §1.2: triage is an operator aid for the two intervention states.
+        if !matches!(job.state, JobState::Escalated | JobState::Stalled) {
+            return Err(CoreError::Conflict(format!(
+                "triage is only available while a job is Escalated or Stalled; \
+                 {owner}/{project}#{seq} is {:?}",
+                job.state
+            )));
+        }
+        // Platform-level image (§1.2). 422 when unset — the action is unavailable.
+        let image = self.config.triage_image.clone().ok_or_else(|| {
+            CoreError::Validation(vec![ValidationError::new(
+                Some(seq),
+                "triage",
+                "TRIAGE_IMAGE is not configured; triage is unavailable",
+            )])
+        })?;
+
+        let prompt = self.build_triage_prompt(owner, project, &job).await?;
+
+        // Provider/model reuse the platform agent defaults (§1.2, §12.4).
+        let provider = provider_name(None, self.config.agent_provider_default.as_deref());
+        let model = self.config.agent_model_default.clone();
+        let session_id = uuid::Uuid::new_v4().to_string();
+
+        // Advisory tag: pin to the latest cycle so the task sorts with the run
+        // it is triaging. Triage is not part of the rework loop.
+        let existing = self.tasks.list_for_job(owner, project, seq).await?;
+        let cycle = existing.iter().map(|t| t.cycle).max().unwrap_or(1);
+        let task_id = existing.len() as u64 + 1;
+
+        let task = Task {
+            id: task_id,
+            job_seq: seq,
+            project: job.project.clone(),
+            phase: TaskPhase::Triage,
+            cycle,
+            kind: TaskKind::Agent { provider, model: model.clone(), prompt: prompt.clone() },
+            state: TaskState::Running,
+            attempt: 1,
+            evaluator: None,
+            container_id: None,
+            session_id: Some(session_id.clone()),
+            result: None,
+            created_at: Utc::now(),
+            started_at: Some(Utc::now()),
+            completed_at: None,
+        };
+        self.tasks.put(&task).await?;
+        self.publish(owner, project, seq, "task-created", serde_json::json!({
+            "task_id": task_id, "phase": "Triage", "cycle": cycle,
+        }))
+        .await?;
+
+        // Minimal launch env: clone the default branch (always present — a
+        // Stalled job may have no job branch) read-only for code context, plus
+        // the platform agent credentials so the CLI can authenticate. No channel
+        // MCP, no NATS credentials — the prompt is self-contained (§1.2).
+        let default_branch = self.repos.default_branch(owner, project).await?;
+        let mut env = HashMap::from([
+            ("JOB_ID".to_string(), seq.to_string()),
+            ("JOB_PROJECT".to_string(), format!("{owner}/{project}")),
+            ("JOB_BRANCH".to_string(), default_branch),
+            ("REPO_URL".to_string(), format!("{}/{owner}/{project}.git", self.config.repo_url_base)),
+        ]);
+        self.inject_git_ssh_command(&mut env);
+        self.inject_platform_agent_secrets(&mut env).await?;
+        // Read-only SSH credential for the clone (empty when no SSH front).
+        let files = self
+            .ssh_credential_files(owner, project, seq, ChannelRole::Eval { task_id }, TRIAGE_TIMEOUT)
+            .await?;
+
+        let config = AgentRunConfig {
+            image,
+            prompt,
+            model,
+            system_prompt: None,
+            mcp_servers: vec![], // no channel MCP (§1.2)
+            files,
+            env,
+            task_timeout: TRIAGE_TIMEOUT,
+            eval_context: vec![],
+            merge_conflict: None,
+            session_id: session_id.clone(),
+        };
+        let provider = self.provider.clone();
+        let tx = self.self_tx.clone().expect("spawned core");
+        let (o, p) = (owner.to_string(), project.to_string());
+        let harvest = self.harvester();
+        tokio::spawn(async move {
+            let (exit_code, assessment, usage) = match provider.run(config).await {
+                Ok(out) => {
+                    // The assessment rides the CLI's JSON result on stdout, so
+                    // harvest it before reporting the exit.
+                    let (assessment, usage) =
+                        harvest.collect_agent(&o, &p, seq, task_id, &out).await;
+                    (out.exit_code, assessment, usage)
+                }
+                Err(e) => {
+                    tracing::error!("triage agent run failed: {e}");
+                    (-1, None, None)
+                }
+            };
+            let _ = tx
+                .send(Msg::TaskExited {
+                    owner: o,
+                    project: p,
+                    seq,
+                    task_id,
+                    exit: TaskExit { exit_code, eval_json: None, usage, assessment },
+                })
+                .await;
+        });
+        Ok(())
+    }
+
+    /// Record a finished triage run (spec §1.2). Writes `TaskResult::Triage` and
+    /// marks the task Done (assessment captured) or Failed (none). **Never**
+    /// changes job state — triage is advisory; the job stays Escalated/Stalled.
+    pub(crate) async fn on_triage_exited(
+        &mut self,
+        owner: &str,
+        project: &str,
+        seq: u64,
+        mut task: Task,
+        exit: TaskExit,
+    ) -> Result<()> {
+        task.completed_at = Some(Utc::now());
+        match exit.assessment {
+            Some(assessment) => {
+                task.state = TaskState::Done;
+                task.result = Some(TaskResult::Triage { assessment, token_usage: exit.usage });
+                self.tasks.put(&task).await?;
+                self.publish(owner, project, seq, "task-completed", serde_json::json!({
+                    "task_id": task.id, "phase": "Triage",
+                }))
+                .await?;
+            }
+            None => {
+                // Container died or produced no parseable result. Record the
+                // attempt so the operator sees it, rather than a silent no-op.
+                task.state = TaskState::Failed;
+                task.result = Some(TaskResult::Triage {
+                    assessment:
+                        "Triage produced no assessment — the agent exited without a result. \
+                         Check the task's captured stdout, and retry."
+                            .to_string(),
+                    token_usage: exit.usage,
+                });
+                self.tasks.put(&task).await?;
+                self.publish(owner, project, seq, "task-failed", serde_json::json!({
+                    "task_id": task.id, "phase": "Triage",
+                }))
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Assemble the triage prompt from the job state the dispatcher already
+    /// holds: the built-in instructions, the brief, why the job stopped (the
+    /// pending escalation task), and every prior task with its result and
+    /// captured stdout. Session transcripts are omitted by design (§1.2).
+    async fn build_triage_prompt(&self, owner: &str, project: &str, job: &Job) -> Result<String> {
+        let mut p = String::from(TRIAGE_PROMPT);
+        p.push_str(&format!(
+            "## Job {}#{} — state {:?}, type `{}`\n",
+            job.project, job.id, job.state, job.r#type
+        ));
+        let brief = job_brief_block(job);
+        if brief.is_empty() {
+            p.push_str("\n(no job brief)\n");
+        } else {
+            p.push_str(&brief);
+            p.push('\n');
+        }
+
+        let tasks = self.tasks.list_for_job(owner, project, job.id).await?;
+
+        // Why the job stopped: the escalation/stall task summoning the human is
+        // the one still Pending (the operator dispatched triage instead of
+        // resolving it).
+        if let Some(TaskKind::Human { prompt }) = tasks
+            .iter()
+            .filter(|t| t.state == TaskState::Pending && matches!(t.kind, TaskKind::Human { .. }))
+            .max_by_key(|t| t.id)
+            .map(|t| &t.kind)
+        {
+            p.push_str("\n---\n## Why the job stopped\n");
+            p.push_str(prompt);
+            p.push('\n');
+        }
+
+        p.push_str("\n---\n## Task log\n");
+        for t in &tasks {
+            // Skip prior triage tasks: an earlier assessment is not evidence,
+            // and feeding it back invites drift.
+            if t.phase == TaskPhase::Triage {
+                continue;
+            }
+            let evaluator = t.evaluator.as_deref().map(|e| format!(" [{e}]")).unwrap_or_default();
+            p.push_str(&format!(
+                "\n### Task {} — {:?}{} (cycle {}, attempt {}) — {:?}\n",
+                t.id, t.phase, evaluator, t.cycle, t.attempt, t.state
+            ));
+            p.push_str(&format!("kind: {}\n", task_kind_label(&t.kind)));
+            if let Some(result) = &t.result {
+                p.push_str(&format!("result: {}\n", render_task_result(result)));
+            }
+            if let Some(artifacts) = &self.artifacts
+                && let Ok(Some(bytes)) =
+                    artifacts.get(owner, project, job.id, t.id, ArtifactKind::Stdout).await
+            {
+                let text = String::from_utf8_lossy(&bytes);
+                p.push_str(&format!("stdout (tail):\n```\n{}\n```\n", tail(&text, STDOUT_TAIL_BYTES)));
+            }
+        }
+        Ok(p)
+    }
+}
+
+fn task_kind_label(kind: &TaskKind) -> &'static str {
+    match kind {
+        TaskKind::Agent { .. } => "agent",
+        TaskKind::Command { .. } => "command",
+        TaskKind::Human { .. } => "human",
+    }
+}
+
+fn render_task_result(result: &TaskResult) -> String {
+    let compact = |v: &serde_json::Value| serde_json::to_string(v).unwrap_or_else(|_| "…".into());
+    let verdict = |pass: bool| if pass { "pass" } else { "fail" };
+    match result {
+        TaskResult::Work { summary, structured, .. } => {
+            let mut s = format!("work done; summary: {}", summary.as_deref().unwrap_or("(none)"));
+            if let Some(st) = structured {
+                s.push_str(&format!("; structured: {}", compact(st)));
+            }
+            s
+        }
+        TaskResult::Command { pass, exit_code, output, .. } => format!(
+            "command {} (exit {}); output tail:\n{}",
+            verdict(*pass),
+            exit_code,
+            tail(output, STDOUT_TAIL_BYTES)
+        ),
+        TaskResult::Agent { pass, abort, structured, .. } => format!(
+            "agent eval {}{}; findings: {}",
+            verdict(*pass),
+            if *abort { " [abort: not satisfiable by rework]" } else { "" },
+            structured.as_ref().map(compact).unwrap_or_else(|| "(none)".into())
+        ),
+        TaskResult::Human { pass, abort, structured, action, operator, .. } => format!(
+            "human {}{}{}; operator {}; notes: {}",
+            verdict(*pass),
+            if *abort { " [abort]" } else { "" },
+            action.map(|a| format!(" [{a:?}]")).unwrap_or_default(),
+            operator,
+            structured.as_ref().map(compact).unwrap_or_else(|| "(none)".into())
+        ),
+        // Skipped from the log above; here only for exhaustiveness.
+        TaskResult::Triage { .. } => "(prior triage assessment)".into(),
+    }
+}
+
+/// The last `max` bytes of `s`, on a char boundary, prefixed with an elision
+/// marker when it was truncated.
+fn tail(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut start = s.len() - max;
+    while start < s.len() && !s.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("…(truncated)…\n{}", &s[start..])
+}

--- a/crates/dispatcher/tests/execution.rs
+++ b/crates/dispatcher/tests/execution.rs
@@ -96,6 +96,8 @@ async fn rig_with_artifacts(artifacts_identity: Option<String>) -> Option<Rig> {
             repo_url_base: "file:///repos".into(),
             nats_url: server.url().into(),
             artifacts_identity,
+            // Enables the operator-dispatched triage action (§1.2).
+            triage_image: Some("triage:latest".into()),
             ..Default::default()
         },
     )
@@ -115,6 +117,7 @@ fn req(r#type: &str) -> CreateJobRequest {
         deps: vec![],
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
     }
 }
@@ -686,4 +689,167 @@ async fn finalize_hard_failure_escalates_instead_of_wedging() {
     }
     let events = event_types(&rig.store).await;
     assert!(events.contains(&"job-escalated".to_string()));
+}
+
+// ── Issue #31: per-job timeout override + operator-dispatched triage ────────
+
+/// The per-job `Job.timeout` override (§1.1) drives the Work agent's own run
+/// timeout, while the evaluator keeps the type default — the override is
+/// Work-scoped. Asserted at the mechanism: the recorded run configs.
+#[tokio::test]
+async fn work_timeout_override_applies_to_work_not_eval() {
+    let Some(rig) = rig().await else { return };
+    let handle = rig.handle.clone();
+
+    rig.provider.on_run(|_| async {}); // work c1
+    let h = handle.clone();
+    rig.provider.on_run(move |_| async move {
+        h.submit_eval("acme", "api", 1, 2, EvalSubmission {
+            pass: true, abort: false, structured: None, token_usage: None,
+        })
+        .await
+        .unwrap();
+    });
+
+    let mut create = req("impl-agent");
+    create.timeout = Some("45m".into());
+    let job = rig.handle.create_job(create).await.unwrap();
+    rig.handle.release_job("acme", "api", job.id).await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Done).await;
+
+    let runs = rig.provider.runs();
+    assert_eq!(runs.len(), 2);
+    // Work: the 45m override. Eval: the type default (no `resources` → 1h).
+    assert_eq!(runs[0].task_timeout, Duration::from_secs(45 * 60));
+    assert_eq!(runs[1].task_timeout, Duration::from_secs(3600));
+}
+
+/// A Work task that outlives the per-job override is killed by the §3.5 timeout
+/// scan — the override applies at kill time, escalating the job.
+#[tokio::test]
+async fn work_timeout_override_times_out_running_work_task() {
+    let Some(rig) = rig().await else { return };
+    // The work "container" never exits on its own — the scan must end it.
+    rig.provider.on_run(|_| async { tokio::time::sleep(Duration::from_secs(30)).await });
+
+    let mut create = req("impl-agent"); // no work_retries → escalates on first fail
+    create.timeout = Some("1s".into());
+    let job = rig.handle.create_job(create).await.unwrap();
+    rig.handle.release_job("acme", "api", job.id).await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Work).await;
+
+    // Age the Running work task past the 1s override, then scan.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    rig.handle.trigger_scan().await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Escalated).await;
+
+    let tasks = rig.store.tasks().await.unwrap().list_for_job("acme", "api", job.id).await.unwrap();
+    let work = tasks.iter().find(|t| t.phase == TaskPhase::Work).unwrap();
+    assert_eq!(work.state, TaskState::Failed, "the override should have timed out the work task");
+}
+
+/// The evaluator keeps the type default even when the job carries a short work
+/// override: a scan after the (short) override elapses must not touch the
+/// Evaluation-phase task — the override does not leak past Work.
+#[tokio::test]
+async fn eval_task_ignores_work_timeout_override() {
+    let Some(rig) = rig().await else { return };
+    rig.provider.on_run(|_| async {}); // work c1: exits immediately
+    // Eval "container" blocks so it is Running when the scan fires.
+    rig.provider.on_run(|_| async { tokio::time::sleep(Duration::from_secs(30)).await });
+
+    let mut create = req("impl-agent");
+    create.timeout = Some("1s".into());
+    let job = rig.handle.create_job(create).await.unwrap();
+    rig.handle.release_job("acme", "api", job.id).await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Evaluation).await;
+
+    // Age well past the 1s work override; the eval task's 1h default protects it.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    rig.handle.trigger_scan().await.unwrap();
+
+    let job_now = rig.store.jobs().await.unwrap().get("acme", "api", job.id).await.unwrap().unwrap();
+    assert_eq!(job_now.state, JobState::Evaluation, "eval must survive the work override");
+    let tasks = rig.store.tasks().await.unwrap().list_for_job("acme", "api", job.id).await.unwrap();
+    let eval = tasks.iter().find(|t| t.phase == TaskPhase::Evaluation).unwrap();
+    assert_eq!(eval.state, TaskState::Running, "the work override must not time out the eval task");
+}
+
+/// A malformed `Job.timeout` is rejected at release (§1.1: parseability
+/// validated at release, not creation) — creation still succeeds.
+#[tokio::test]
+async fn malformed_timeout_override_rejected_at_release() {
+    let Some(rig) = rig().await else { return };
+    let mut create = req("impl-agent");
+    create.timeout = Some("2 hours".into()); // not a valid duration string
+    let job = rig.handle.create_job(create).await.unwrap(); // creation is permissive
+    let err = rig.handle.release_job("acme", "api", job.id).await.unwrap_err();
+    match err {
+        dispatcher::core::CoreError::Validation(errs) => {
+            assert!(errs.iter().any(|e| e.field == "timeout"), "{errs:?}");
+        }
+        other => panic!("expected a validation error on timeout, got {other:?}"),
+    }
+}
+
+/// Operator-dispatched triage (§1.2) over an Escalated job: creates a Triage
+/// agent task, captures the assessment from the CLI's JSON result (no channel
+/// MCP), and leaves the job Escalated — purely advisory.
+#[tokio::test]
+async fn triage_on_escalated_job_records_assessment_and_leaves_escalated() {
+    let (identity, _public) = store::secrets::generate_age_keypair();
+    let Some(rig) = rig_with_artifacts(Some(identity)).await else { return };
+
+    // Drive the job to Escalated: both work attempts fail (flaky: work_retries 1).
+    rig.provider.script_exits([2, 3]);
+    let job = rig.handle.create_job(req("flaky")).await.unwrap();
+    rig.handle.release_job("acme", "api", job.id).await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Escalated).await;
+
+    // The triage agent's assessment rides the CLI's JSON `result` on stdout.
+    rig.backend.put_logs(
+        br#"{"type":"result","subtype":"success","is_error":false,"result":"Root cause: the work container exited non-zero on both attempts. Recommend Revoke.","session_id":"t","usage":{"input_tokens":10,"output_tokens":20}}"#
+            .to_vec(),
+    );
+
+    rig.handle.triage_job("acme", "api", job.id).await.unwrap();
+
+    // Poll for the Triage task to land with a recorded assessment.
+    let tasks = rig.store.tasks().await.unwrap();
+    let mut triage = None;
+    for _ in 0..100 {
+        let log = tasks.list_for_job("acme", "api", job.id).await.unwrap();
+        if let Some(t) = log.iter().find(|t| t.phase == TaskPhase::Triage && t.result.is_some()) {
+            triage = Some(t.clone());
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let triage = triage.expect("triage task recorded a result");
+    assert_eq!(triage.state, TaskState::Done);
+    match triage.result.as_ref().unwrap() {
+        types::TaskResult::Triage { assessment, .. } => {
+            assert!(assessment.contains("Recommend Revoke"), "{assessment}");
+        }
+        other => panic!("expected a Triage result, got {other:?}"),
+    }
+
+    // Advisory: the job state is untouched.
+    let job_now = rig.store.jobs().await.unwrap().get("acme", "api", job.id).await.unwrap().unwrap();
+    assert_eq!(job_now.state, JobState::Escalated);
+
+    // The run used the platform triage image and carried no channel MCP.
+    let last = rig.provider.runs().pop().unwrap();
+    assert_eq!(last.image, "triage:latest");
+    assert!(last.mcp_servers.is_empty(), "triage runs without the channel MCP");
+}
+
+/// Triage is rejected unless the job is Escalated or Stalled (§1.2).
+#[tokio::test]
+async fn triage_rejected_on_non_intervention_state() {
+    let Some(rig) = rig().await else { return };
+    // A freshly created job is Frozen.
+    let job = rig.handle.create_job(req("impl-agent")).await.unwrap();
+    let err = rig.handle.triage_job("acme", "api", job.id).await.unwrap_err();
+    assert!(matches!(err, dispatcher::core::CoreError::Conflict(_)), "{err:?}");
 }

--- a/crates/dispatcher/tests/gate_and_human.rs
+++ b/crates/dispatcher/tests/gate_and_human.rs
@@ -110,6 +110,7 @@ fn req(r#type: &str) -> CreateJobRequest {
         deps: vec![],
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
     }
 }

--- a/crates/dispatcher/tests/lifecycle.rs
+++ b/crates/dispatcher/tests/lifecycle.rs
@@ -92,6 +92,7 @@ fn req(r#type: &str, deps: &[u64]) -> CreateJobRequest {
         deps: deps.to_vec(),
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
     }
 }

--- a/crates/dispatcher/tests/nats_submit.rs
+++ b/crates/dispatcher/tests/nats_submit.rs
@@ -97,6 +97,7 @@ async fn submits_flow_over_nats_to_the_core() {
             deps: vec![],
             knowledge_tags: vec![],
             eval: vec![],
+            timeout: None,
             factory: None,
         })
         .await
@@ -197,6 +198,7 @@ async fn channel_posts_accumulate_as_history_instead_of_overwriting() {
             deps: vec![],
             knowledge_tags: vec![],
             eval: vec![],
+            timeout: None,
             factory: None,
         })
         .await

--- a/crates/dispatcher/tests/origin.rs
+++ b/crates/dispatcher/tests/origin.rs
@@ -394,6 +394,7 @@ async fn held_job_lands_after_merged_release_sync() {
             deps: vec![],
             knowledge_tags: vec![],
             eval: vec![],
+            timeout: None,
             factory: None,
         })
         .await
@@ -486,6 +487,7 @@ async fn reserved_chug_secrets_never_reach_containers() {
             deps: vec![],
             knowledge_tags: vec![],
             eval: vec![],
+            timeout: None,
             factory: None,
         })
         .await

--- a/crates/dispatcher/tests/recovery.rs
+++ b/crates/dispatcher/tests/recovery.rs
@@ -90,6 +90,7 @@ fn req(r#type: &str) -> CreateJobRequest {
         deps: vec![],
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
     }
 }
@@ -136,6 +137,7 @@ async fn restart_recovers_orphaned_running_work_task() {
         base_ref: Some(head),
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
         created_at: Utc::now(),
         ready_at: Some(Utc::now()),
@@ -214,6 +216,7 @@ async fn restart_lands_job_orphaned_in_wrapup() {
         base_ref: Some(head),
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
         created_at: Utc::now(),
         ready_at: Some(Utc::now()),
@@ -392,6 +395,7 @@ async fn restart_preserves_the_submitted_summary_for_the_squash_commit() {
         base_ref: Some(head),
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
         created_at: Utc::now(),
         ready_at: Some(Utc::now()),

--- a/crates/store/src/subjects.rs
+++ b/crates/store/src/subjects.rs
@@ -92,6 +92,11 @@ pub fn jobs_revoke(owner: &str, project: &str, seq: u64) -> String {
     format!("req.jobs.revoke.{owner}.{project}.{seq}")
 }
 
+/// Operator-dispatched advisory triage (spec §1.2).
+pub fn jobs_triage(owner: &str, project: &str, seq: u64) -> String {
+    format!("req.jobs.triage.{owner}.{project}.{seq}")
+}
+
 /// Create a project (§12.2 via the API): bare repo, hook, starter template,
 /// counter. Owner/name ride in the payload — they are being validated, so
 /// they cannot ride in the subject.

--- a/crates/store/tests/nats_store.rs
+++ b/crates/store/tests/nats_store.rs
@@ -21,6 +21,7 @@ fn job(seq: u64) -> Job {
         base_ref: None,
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
         created_at: Utc::now(),
         ready_at: None,

--- a/crates/types/src/job.rs
+++ b/crates/types/src/job.rs
@@ -42,6 +42,14 @@ pub struct Job {
     /// collisions with the type's evaluators are a release-time error.
     #[serde(default)]
     pub eval: Vec<Evaluator>,
+    /// Optional per-job work-task timeout override (duration string, §1.1).
+    /// Layers over the job type's `resources.task_timeout` exactly like [`eval`]
+    /// layers over the type's evaluators — but for Work tasks only; evaluators
+    /// keep the type default. Any valid duration (shorter or longer). Parseability
+    /// is validated at release, consistent with "wiring validated at release, not
+    /// creation". None means the type default applies.
+    #[serde(default)]
+    pub timeout: Option<String>,
     /// Factory name when created by a factory triage agent (spec §13); None for
     /// operator-created jobs.
     pub factory: Option<String>,
@@ -102,6 +110,31 @@ mod tests {
         assert_eq!(job.id, 42);
         assert_eq!(job.state, JobState::Frozen);
         assert_eq!(job.deps, vec![11, 22]);
+        // `timeout` is optional and defaults to None on records that predate it.
+        assert_eq!(job.timeout, None);
+        let back = serde_json::to_string(&job).unwrap();
+        let again: Job = serde_json::from_str(&back).unwrap();
+        assert_eq!(job, again);
+    }
+
+    #[test]
+    fn job_round_trips_with_timeout_override() {
+        let json = r#"{
+          "id": 7,
+          "project": "acme/api",
+          "type": "deploy",
+          "deps": [],
+          "state": "Frozen",
+          "branch": "job/7",
+          "base_ref": null,
+          "knowledge_tags": [],
+          "timeout": "45m",
+          "factory": null,
+          "created_at": "2026-07-20T10:00:00Z",
+          "ready_at": null
+        }"#;
+        let job: Job = serde_json::from_str(json).unwrap();
+        assert_eq!(job.timeout.as_deref(), Some("45m"));
         let back = serde_json::to_string(&job).unwrap();
         let again: Job = serde_json::from_str(&back).unwrap();
         assert_eq!(job, again);

--- a/crates/types/src/platform.rs
+++ b/crates/types/src/platform.rs
@@ -30,6 +30,10 @@ pub struct DispatcherConfigSnapshot {
     pub agent_provider_default: String,
     /// `AGENT_MODEL_DEFAULT`, if set.
     pub agent_model_default: Option<String>,
+    /// `TRIAGE_IMAGE` — platform image for operator-dispatched triage agents
+    /// (§1.2). None → the triage action is unavailable.
+    #[serde(default)]
+    pub triage_image: Option<String>,
     /// `REPOS_ROOT` — bare repos on disk.
     pub repos_root: String,
     /// `REPO_URL_BASE` — clone URL base injected into containers.

--- a/crates/types/src/task.rs
+++ b/crates/types/src/task.rs
@@ -44,6 +44,11 @@ pub enum TaskPhase {
     /// squash commit (spec §3.3 Merge Gate). Only present when the default
     /// branch HEAD moved past `base_ref` while the job was in flight.
     MergeGate,
+    /// Operator-dispatched triage (spec §1.2): an advisory agent run over the
+    /// whole job state that produces a written assessment + recommendation.
+    /// Purely advisory — it never drives a job transition. Only created while
+    /// the job is Escalated or Stalled, and may be repeated.
+    Triage,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -103,6 +108,14 @@ pub enum TaskResult {
         action: Option<EscalationAction>,
         operator: String,
         resolved_at: DateTime<Utc>,
+    },
+    /// Result of an operator-dispatched triage task (spec §1.2). The agent's
+    /// written assessment + recommendation, captured from the CLI JSON result
+    /// text (triage runs without the channel MCP, so there is no `submit_result`).
+    /// Advisory only — never consulted by any state transition.
+    Triage {
+        assessment: String,
+        token_usage: Option<TokenUsage>,
     },
 }
 
@@ -182,6 +195,37 @@ mod tests {
                 action: EscalationAction::Revoke,
                 structured: None
             }
+        );
+    }
+
+    #[test]
+    fn triage_phase_and_result_round_trip() {
+        // TaskPhase::Triage round-trips.
+        let p: TaskPhase = serde_json::from_str(r#""Triage""#).unwrap();
+        assert_eq!(p, TaskPhase::Triage);
+        assert_eq!(serde_json::to_string(&p).unwrap(), r#""Triage""#);
+
+        // TaskResult::Triage round-trips, with and without token usage.
+        let with_usage = TaskResult::Triage {
+            assessment: "Work failed on a missing migration; recommend Revoke.".into(),
+            token_usage: Some(TokenUsage {
+                input_tokens: 10,
+                output_tokens: 20,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            }),
+        };
+        let json = serde_json::to_string(&with_usage).unwrap();
+        assert!(json.contains(r#""kind":"Triage""#));
+        assert_eq!(serde_json::from_str::<TaskResult>(&json).unwrap(), with_usage);
+
+        let no_usage: TaskResult = serde_json::from_str(
+            r#"{ "kind": "Triage", "assessment": "insufficient signal", "token_usage": null }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            no_usage,
+            TaskResult::Triage { assessment: "insufficient signal".into(), token_usage: None }
         );
     }
 }

--- a/crates/vcs/tests/repo_test.rs
+++ b/crates/vcs/tests/repo_test.rs
@@ -18,6 +18,7 @@ fn job(repo: &TempRepo, id: u64, state: JobState, base_ref: Option<String>) -> J
         base_ref,
         knowledge_tags: vec![],
         eval: vec![],
+        timeout: None,
         factory: None,
         created_at: chrono::Utc::now(),
         ready_at: None,

--- a/design-lifecycle.md
+++ b/design-lifecycle.md
@@ -178,6 +178,21 @@ Triage means the platform has run out of automation for *this* job. Its outlets:
 Triage agents are declared, not implicit — a job type (or project config) opts
 in. An operator-facing escalation never silently becomes an agent decision.
 
+### Manual triage (advisory) — the operator-dispatched middle ground
+
+Between "escalate to a human" and "an agent creates a job" sits a third, human-in-
+command outlet, live today: **manual triage**. When a job is `Escalated` or
+`Stalled`, the operator can dispatch a triage agent (`POST .../jobs/{seq}/triage`,
+§1.2) that reads the whole job state — brief, escalation reason, every task's
+result, and the captured Stdout logs — and writes an **assessment +
+recommendation** (`TaskPhase::Triage` / `TaskResult::Triage`). It is purely
+advisory: it never changes job state (no §2.1 transition), so the operator still
+owns the Retry / Resolve / Revoke decision — the assessment just informs it.
+Unlike the declared triage agents above, it is dispatched on demand, not wired
+into the escalation edge, and runs in a platform image (`TRIAGE_IMAGE`) so it
+works on any job type. It is the "help me understand why this failed" button,
+distinct from "let automation try once more."
+
 ---
 
 ## Decision: eval criteria are a floor, additive per job

--- a/spec.md
+++ b/spec.md
@@ -21,6 +21,7 @@ pub struct Job {
     pub base_ref: Option<String>,          // exact HEAD of default branch; set/updated at every Ready-transition (Frozen→Ready and Blocked→Ready) and on squash-merge conflict; None until job first enters Ready
     pub knowledge_tags: Vec<String>,       // union of job type defaults and operator-supplied tags at creation
     pub eval: Vec<Evaluator>,              // additive per-job evaluators, layered on top of the type's eval list at execution; the type's evaluators are a floor — creation can add criteria, never remove or override them; name collisions are a release-time error (see design-lifecycle.md)
+    pub timeout: Option<String>,           // optional per-job work-task timeout override (duration string, e.g. "45m"), layering over the type's resources.task_timeout exactly like `eval` layers over the type's evaluators — but Work-phase tasks only; evaluators keep the type default. Any valid duration. Parseability validated at release. None → the type default applies
     pub factory: Option<String>,           // factory name when created by a factory triage agent (see §13); None for operator-created jobs
     pub created_at: DateTime<Utc>,
     pub ready_at: Option<DateTime<Utc>>,   // set once (immutably) when job first enters Ready; anchor for job_deadline; None until then
@@ -48,6 +49,7 @@ Example record:
   "base_ref": null,
   "knowledge_tags": ["rust", "rest-api", "payments/stripe-integration"],
   "eval": [],
+  "timeout": null,
   "factory": null,
   "created_at": "2026-04-05T10:00:00Z",
   "ready_at": null
@@ -312,7 +314,7 @@ pub struct Task {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
-pub enum TaskPhase { Work, Evaluation, MergeGate }
+pub enum TaskPhase { Work, Evaluation, MergeGate, Triage }
 
 pub enum TaskKind {
     Command { run: String },
@@ -327,6 +329,7 @@ pub enum TaskResult {
     Command { pass: bool, exit_code: i32, output: String, structured: Option<serde_json::Value> },
     Agent   { pass: bool, abort: bool, structured: Option<serde_json::Value>, token_usage: Option<TokenUsage> },
     Human   { pass: bool, abort: bool, structured: Option<serde_json::Value>, action: Option<EscalationAction>, operator: String, resolved_at: DateTime<Utc> },
+    Triage  { assessment: String, token_usage: Option<TokenUsage> },  // operator-dispatched advisory triage (see below); assessment is the agent's written recommendation, captured from the CLI result text (no submit_result — triage runs without the channel MCP)
 }
 
 pub enum EscalationAction { Retry, Resolve, Revoke }
@@ -404,6 +407,8 @@ pub enum TaskResolution {
 Escalation never bypasses evaluation — `Done` is only reachable via an evaluation pass.
 
 **Pre-Work escalations** — escalations raised before any work task exists put the job in the **`Stalled`** state (not `Escalated`): Blocked→Stalled on re-validation failure (see §2.1); job-deadline escalation from Ready (Ready→Stalled, see §3.5). They accept only `Retry` and `Revoke`; `Resolve` is rejected with 400. For these, `Retry` re-attempts the failed step — re-runs Ready-transition re-validation for the former, re-enqueues the job for execution for the latter — rather than creating a work task. The distinction is carried by the state itself: `Stalled` has no transition into `Work` or `Evaluation`, so a mis-routed `Resolve` is impossible by construction rather than guarded at resolve time.
+
+**Manual triage (advisory)** — when a job is `Escalated` or `Stalled`, the operator may **dispatch a triage task** (`POST .../jobs/{seq}/triage`, §6.2) to help understand *why* it failed. The dispatcher runs an agent over the whole job state — the job brief, the escalation reason, every task that ran with its result, and the per-task captured Stdout logs (decrypted via the `age_artifacts` identity) — and records its written assessment + recommendation as a `TaskPhase::Triage` task carrying `TaskResult::Triage`. Triage is **purely advisory**: it never changes job state and creates no job transition (there is no `Triage` row in the §2.1 table). The operator still decides Retry / Resolve / Revoke. It runs in a platform-level image (`TRIAGE_IMAGE`, §12.4) with provider/model from the platform agent defaults, so it works uniformly on any job type (agent/command/human). The run is self-contained — the prompt embeds the job state in plaintext and there is no channel MCP, so the assessment is read back from the agent CLI's own JSON result text rather than a `submit_result` call. Session transcripts are omitted from the prompt by design (opaque, large, low value). Triage may be dispatched repeatedly; a revoke's container cleanup kills an in-flight triage.
 
 **Example task log:**
 
@@ -829,7 +834,7 @@ See §2.1 (state table rows for `Escalated`) and §1.2 (EscalationAction, TaskRe
 
 ### 3.5 Timeout and Deadline
 
-**Task timeout scan** — dispatcher periodically scans for tasks in `Running` state where `now - started_at > job.resources.task_timeout`. The task is marked Failed and retry logic applies. Tasks in `Pending` state are not timed out — the clock starts when execution begins. Human tasks (any phase or type) are excluded from the timeout scan — they have no timeout and no automatic abandonment. This is intentional: human review gates are explicit decisions, not time-bounded.
+**Task timeout scan** — dispatcher periodically scans for tasks in `Running` state where `now - started_at > task_timeout`. The task is marked Failed and retry logic applies. The applicable `task_timeout` is **per task phase**: a Work-phase task uses the per-job override `Job.timeout` (§1.1) when set, else the type's `resources.task_timeout`; every other phase (Evaluation, MergeGate, Triage) uses the type default. This is what keeps the override work-scoped — evaluators are unaffected by it. The same resolved Work timeout also governs the work agent's own container deadline and the §7.4 credential TTLs, so a longer override does not outlive its credentials. Tasks in `Pending` state are not timed out — the clock starts when execution begins. Human tasks (any phase or type) are excluded from the timeout scan — they have no timeout and no automatic abandonment. This is intentional: human review gates are explicit decisions, not time-bounded.
 
 **Job deadline scan** — if `job_deadline` is set, the dispatcher scans for jobs in Work, Evaluation, or Ready state where `ready_at` is set and `now - ready_at > job_deadline`. Any such job is transitioned to a human-intervention state with a Human task explaining the deadline was exceeded: a job still in **Ready** (no work task yet) goes to **Stalled** (pre-work — Retry re-enqueues, Resolve rejected); a job in **Work** or **Evaluation** goes to **Escalated** (post-work — Resolve also available). If the job has a Running container at the time of deadline expiry, the dispatcher kills it (same as the timeout scan) first. Jobs already in Escalated or Stalled state are excluded — a human is already engaged. Jobs in Frozen or Blocked state (and in WrapUp — landing is platform-owned, like the merge queue) are not checked; the clock does not start until `ready_at` is set (i.e., when the job first enters Ready).
 
@@ -1286,6 +1291,7 @@ GET    /api/v1/projects/{owner}/{project}/jobs/{seq}                → 200 OK; 
 GET    /api/v1/projects/{owner}/{project}/jobs/{seq}/criteria       → 200 OK; body: { ref, wrap_up, evaluators: [Evaluator + source], errors } — the criteria the job will be (or was) judged against, resolved at base_ref (or default HEAD before Ready)
 POST   /api/v1/projects/{owner}/{project}/jobs/{seq}/release        → 200 OK; body: Job (updated state); 422 with error list if validation fails
 POST   /api/v1/projects/{owner}/{project}/jobs/{seq}/revoke         → 200 OK; body: Job (updated state); 409 if already Done or Revoked
+POST   /api/v1/projects/{owner}/{project}/jobs/{seq}/triage         → 200 OK; body: Job (unchanged); dispatches an advisory triage agent (§1.2). 409 unless the job is Escalated or Stalled; 422 if TRIAGE_IMAGE is unconfigured. Member+. Never changes job state
 
 # Graph
 GET    /api/v1/projects/{owner}/{project}/graph                     → 200 OK; body: Job[] (all jobs in the project)
@@ -1789,6 +1795,7 @@ Dispatcher configuration (environment variables or config file):
 ```
 AGENT_PROVIDER_DEFAULT   claude | codex      Required. No built-in default — dispatcher refuses to start without this.
 AGENT_MODEL_DEFAULT      string              Optional. If unset, the provider's built-in default model is used.
+TRIAGE_IMAGE             string              Optional. Platform image for operator-dispatched triage agents (§1.2). Provider/model reuse AGENT_PROVIDER_DEFAULT / AGENT_MODEL_DEFAULT. Unset → the triage action is unavailable (422). A platform-level image (rather than the failing job's own type image) so triage works uniformly across agent/command/human job types.
 ```
 
 If a job type declares `provider` and/or `model` at the `work:` level or per evaluator, those override the platform defaults for that job or evaluator. If neither the job type nor the platform config specifies a provider, the dispatcher fails to start with a configuration error.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -102,6 +102,9 @@ export interface Job {
   knowledge_tags: string[]
   /** additive per-job evaluators, layered on top of the type's list */
   eval: Evaluator[]
+  /** per-job work-task timeout override (duration string), layering over the
+   *  type's resources.task_timeout; null → the type default applies */
+  timeout: string | null
   factory: string | null
   created_at: string
   ready_at: string | null
@@ -118,7 +121,7 @@ export interface Task {
   id: number
   job_seq: number
   project: string
-  phase: 'Work' | 'Evaluation' | 'MergeGate'
+  phase: 'Work' | 'Evaluation' | 'MergeGate' | 'Triage'
   cycle: number
   kind: TaskKind
   state: 'Pending' | 'Running' | 'Done' | 'Failed'
@@ -196,6 +199,8 @@ export interface DispatcherSnapshot {
   nodes: WorkerNode[]
   agent_provider_default: string
   agent_model_default: string | null
+  /** platform image for operator-dispatched triage agents; null → unavailable */
+  triage_image: string | null
   repos_root: string
   repo_url_base: string
   nats_url: string
@@ -280,7 +285,7 @@ export const api = {
     req<Job[]>('GET', `/api/v1/projects/${owner}/${project}/jobs`),
   job: (owner: string, project: string, seq: number) =>
     req<Job>('GET', `/api/v1/projects/${owner}/${project}/jobs/${seq}`),
-  createJob: (owner: string, project: string, body: { type: string; title?: string; description?: string; deps?: number[]; knowledge_tags?: string[]; eval?: Evaluator[] }) =>
+  createJob: (owner: string, project: string, body: { type: string; title?: string; description?: string; deps?: number[]; knowledge_tags?: string[]; eval?: Evaluator[]; timeout?: string }) =>
     req<Job>('POST', `/api/v1/projects/${owner}/${project}/jobs`, body),
   criteria: (owner: string, project: string, seq: number) =>
     req<JobCriteria>('GET', `/api/v1/projects/${owner}/${project}/jobs/${seq}/criteria`),
@@ -288,6 +293,9 @@ export const api = {
     req<Job>('POST', `/api/v1/projects/${owner}/${project}/jobs/${seq}/release`),
   revoke: (owner: string, project: string, seq: number) =>
     req<Job>('POST', `/api/v1/projects/${owner}/${project}/jobs/${seq}/revoke`),
+  /** Dispatch an advisory triage agent over an Escalated/Stalled job (§1.2). */
+  triage: (owner: string, project: string, seq: number) =>
+    req<Job>('POST', `/api/v1/projects/${owner}/${project}/jobs/${seq}/triage`),
 
   pendingTasks: (owner: string, project: string) =>
     req<Task[]>('GET', `/api/v1/projects/${owner}/${project}/tasks/pending`),

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -59,6 +59,10 @@ export function JobDetail() {
   const pendingHuman = tasks.filter(
     (t) => t.kind.kind === 'Human' && t.state === 'Pending',
   )
+  // Advisory triage runs (§1.2), newest first.
+  const triageTasks = tasks
+    .filter((t) => t.phase === 'Triage')
+    .sort((a, b) => b.id - a.id)
 
   return (
     <div className="page">
@@ -101,6 +105,14 @@ export function JobDetail() {
           </dd>
           <dt>created</dt>
           <dd>{new Date(job.created_at).toLocaleString()}</dd>
+          {job.timeout && (
+            <>
+              <dt>timeout</dt>
+              <dd title="per-job work-task timeout override (evaluators keep the type default)">
+                <code>{job.timeout}</code> <span className="dim">override</span>
+              </dd>
+            </>
+          )}
           {criteria?.wrap_up && (
             <>
               <dt>wrap-up</dt>
@@ -115,6 +127,14 @@ export function JobDetail() {
               onClick={() => api.release(owner, project, job.id).then(refresh, setActionError(setError))}
             >
               ▶ run
+            </button>
+          )}
+          {(job.state === 'Escalated' || job.state === 'Stalled') && (
+            <button
+              title="run an advisory triage agent over the job state — assessment + recommendation, no change to the job"
+              onClick={() => api.triage(owner, project, job.id).then(refresh, setActionError(setError))}
+            >
+              dispatch triage
             </button>
           )}
           {job.state !== 'Done' && job.state !== 'Revoked' && (
@@ -150,6 +170,28 @@ export function JobDetail() {
               />
             </div>
           ))}
+        </section>
+      )}
+
+      {triageTasks.length > 0 && (
+        <section className="card">
+          <h2>Triage <span className="dim">advisory — nothing changed on the job</span></h2>
+          {triageTasks.map((t) => {
+            const r = t.result as Record<string, unknown> | null
+            const assessment = r && typeof r.assessment === 'string' ? r.assessment : null
+            return (
+              <div className="triage-task" key={t.id}>
+                <div className="inbox-head">
+                  task {t.id} · cycle {t.cycle} · <TaskBadge state={t.state} />
+                </div>
+                {assessment ? (
+                  <pre className="prompt">{assessment}</pre>
+                ) : (
+                  <div className="dim">{t.state === 'Running' ? 'running…' : 'no assessment produced'}</div>
+                )}
+              </div>
+            )
+          })}
         </section>
       )}
 
@@ -270,7 +312,9 @@ function resultSummary(t: Task): string {
   if ('exit_code' in r && typeof r.exit_code === 'number') parts.push(`exit ${r.exit_code}`)
   if ('summary' in r && r.summary) parts.push(String(r.summary))
   if ('action' in r && r.action) parts.push(String(r.action))
-  if ('structured' in r && r.structured) parts.push(JSON.stringify(r.structured))
+  // Triage carries prose; the full text renders in the assessments section.
+  if ('assessment' in r && typeof r.assessment === 'string') parts.push('assessment ↓')
+  else if ('structured' in r && r.structured) parts.push(JSON.stringify(r.structured))
   return parts.join(' · ').slice(0, 200)
 }
 

--- a/web/src/pages/NewJob.tsx
+++ b/web/src/pages/NewJob.tsx
@@ -52,7 +52,7 @@ export function NewJobPage() {
           availableTags={availableTags}
           jobs={jobs}
           initialType={params.get('type') ?? ''}
-          onCreate={(type, title, description, deps, knowledgeTags, evals) =>
+          onCreate={(type, title, description, deps, knowledgeTags, evals, timeout) =>
             api
               .createJob(owner, project, {
                 type,
@@ -61,6 +61,7 @@ export function NewJobPage() {
                 deps: deps.length ? deps : undefined,
                 knowledge_tags: knowledgeTags.length ? knowledgeTags : undefined,
                 eval: evals.length ? evals : undefined,
+                timeout: timeout || undefined,
               })
               .then(
                 (job) => navigate(`/p/${owner}/${project}/jobs/${job.id}`),
@@ -103,6 +104,7 @@ function CreateJob({
     deps: number[],
     knowledgeTags: string[],
     evals: Evaluator[],
+    timeout: string,
   ) => void
 }) {
   const [type, setType] = useState(initialType)
@@ -133,6 +135,9 @@ function CreateJob({
   const [evalRows, setEvalRows] = useState<EvalRow[]>([])
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [tags, setTags] = useState('')
+  const [timeout, setTimeout] = useState('')
+  // The type's default work-task timeout, shown as the input placeholder.
+  const typeTimeout = typeDetail?.job_type?.resources?.task_timeout ?? null
 
   function toggleTag(tag: string) {
     setSelectedTags((ts) => (ts.includes(tag) ? ts.filter((t) => t !== tag) : [...ts, tag]))
@@ -187,7 +192,7 @@ function CreateJob({
       return
     }
     setError(null)
-    onCreate(type, title.trim(), description.trim(), deps, knowledgeTags, evals)
+    onCreate(type, title.trim(), description.trim(), deps, knowledgeTags, evals, timeout.trim())
   }
 
   return (
@@ -403,6 +408,20 @@ function CreateJob({
             ))}
         </datalist>
       </div>
+
+      <label className="field">
+        <span>
+          Work timeout{' '}
+          <span className="dim">
+            (optional; overrides the type default for this job's work — evaluators keep the default)
+          </span>
+        </span>
+        <input
+          value={timeout}
+          onChange={(e) => setTimeout(e.target.value)}
+          placeholder={typeTimeout ? `${typeTimeout} (type default)` : 'e.g. 45m, 2h, 1h30m'}
+        />
+      </label>
 
       <div className="create-actions">
         <button type="submit">create job</button>

--- a/web/src/pages/PlatformSettings.tsx
+++ b/web/src/pages/PlatformSettings.tsx
@@ -85,6 +85,8 @@ export function PlatformSettingsPage() {
                   </dd>
                   <dt>model</dt>
                   <dd>{d.agent_model_default ? <code>{d.agent_model_default}</code> : <span className="dim">—</span>}</dd>
+                  <dt title="platform image for operator-dispatched triage agents (§1.2)">triage image</dt>
+                  <dd>{d.triage_image ? <code>{d.triage_image}</code> : <span className="dim">— (triage unavailable)</span>}</dd>
                   <dt>secrets encryption</dt>
                   <dd>{d.secrets_encryption ? <span className="badge">on</span> : <span className="dim">off</span>}</dd>
                 </dl>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -411,11 +411,13 @@ td.actions button {
 .inbox h2 {
   color: var(--orange);
 }
-.inbox-task {
+.inbox-task,
+.triage-task {
   border-top: 1px solid var(--border);
   padding: var(--sp-3) 0;
 }
-.inbox-task:first-of-type {
+.inbox-task:first-of-type,
+.triage-task:first-of-type {
   border-top: none;
 }
 .prompt {


### PR DESCRIPTION
Implements #31 — two operator-facing capabilities for jobs that go wrong. Both are spec-normative; `spec.md`/`design-lifecycle.md` are updated alongside the code.

## Feature 1 — Manual triage task (advisory)
When a job is `Escalated` or `Stalled`, an operator can **dispatch a triage agent** over the whole job state (brief, escalation reason, every task's result, and the per-task decrypted Stdout logs). It records a `TaskPhase::Triage` task carrying `TaskResult::Triage { assessment, token_usage }` with the agent's written assessment + recommendation.

- **Purely advisory** — no `state.rs` change, no job transition; the operator still decides Retry / Resolve / Revoke.
- Runs in a platform `TRIAGE_IMAGE` with the platform agent defaults, so it works uniformly on agent/command/human job types.
- Self-contained: the prompt embeds the job state, there's no channel MCP, and the assessment is read back from the CLI's own JSON result text (new `agent::claude::parse_result`) rather than a `submit_result` call.
- Path mirrors revoke end to end: `subjects::jobs_triage` → `Msg::TriageJob`/`CoreHandle::triage_job` → `req.jobs.triage` handler → `routes::jobs_triage` (`member_on`) + `POST .../jobs/{seq}/triage`. Guards: 409 unless Escalated/Stalled, 422 if `TRIAGE_IMAGE` unconfigured.

## Feature 2 — Per-job timeout override
New optional `Job.timeout` (duration string) layers over the type's `resources.task_timeout` — **Work tasks only**; evaluators keep the type default. Resolved once onto `ExecState.work_timeout` at `enter_work`, applied to the work agent's run timeout and the §7.4 NATS/SSH credential TTLs, and enforced per-phase in `scan_task_timeouts` (Work → override, else type default). Parseability validated at **release**, not creation.

## web
Dispatch-triage button (gated Escalated/Stalled) + assessments card on JobDetail; work-timeout input on the create form (placeholder = type default) + override shown on JobDetail; `triage_image` on Platform Settings.

## Spec & docs
`spec.md` §1.1 (`Job.timeout`), §1.2 (`TaskPhase::Triage`, `TaskResult::Triage`, advisory-triage prose), §3.5 (per-phase timeout), §6.2 (route), §12.4 (`TRIAGE_IMAGE`); `design-lifecycle.md` escalation note. No `job-type.schema.json` change — the override lives on the Job, not the type.

## Verification
- `cargo build` (workspace), `types` (round-trips), `agent` (`parse_result`), `dispatcher --lib` — green.
- 6 new dispatcher integration tests — green: override times out a Work task but not an eval task in the same job; override threads to the work run but not the eval run; malformed timeout rejected at release; triage on an Escalated job records the assessment and leaves it Escalated; triage rejected off Escalated/Stalled.
- `api` route-wiring test (`config_settings`) — green (`triage_image` surfaced).
- `web` `npm run build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)