### PR TITLE
docs(prod): document Mac Mini bootstrap gotchas

### DIFF
--- a/deploy/prod/README.md
+++ b/deploy/prod/README.md
@@ -20,9 +20,18 @@ only *consumes* `main`.
 ## 0. Prerequisites (one-time, on the Mini)
 
 ```sh
-# Toolchain + runtime
-brew install colima docker docker-compose node age rclone cloudflared
+# Toolchain + runtime. buildx + compose are required (build.sh uses `docker build
+# --output`; boot.sh/update.sh use `docker compose`). cloudflared is OPTIONAL —
+# only for a public tunnel (§5); the default Tailscale Serve path needs no install.
+brew install colima docker docker-buildx docker-compose node age rclone
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh   # Rust (edition 2024 needs =>1.85)
+
+# Homebrew ships buildx/compose as standalone binaries; link them as docker CLI
+# plugins so `docker build --output` and `docker compose` resolve (else build.sh
+# fails "unknown flag: --output" and boot.sh fails "unknown shorthand flag: 'f'").
+mkdir -p ~/.docker/cli-plugins
+ln -sfn "$(brew --prefix)/opt/docker-buildx/bin/docker-buildx"  ~/.docker/cli-plugins/docker-buildx
+ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
 
 # Give Colima room for cargo builds + agent containers
 colima start --cpu 4 --memory 8 --disk 100
@@ -41,6 +50,17 @@ Also:
 - **Repo access** — `deploy.yml` runs only if `Kasofsk/chuggernaut` is granted to
   the org runner group. Transfer/keep the repo under the org, and **make it
   private** (self-hosted runners + public repos = fork PRs running on your box).
+- **Deploy key** — the deployed checkout (`$CHUG_REPO`) fetches `main` over SSH in
+  `update.sh`, independently of the Actions runner's token. Give the Mini a
+  **read-only** GitHub deploy key and register the public half under the repo's
+  **Settings → Deploy keys** (leave write access off):
+  ```sh
+  ssh-keygen -t ed25519 -N "" -f ~/.ssh/chuggernaut_deploy   # add the .pub to Deploy keys
+  printf '\nHost github.com\n  IdentityFile ~/.ssh/chuggernaut_deploy\n  IdentitiesOnly yes\n' >> ~/.ssh/config
+  ```
+- **Colima has no `/var/run/docker.sock`** — the dispatcher (a native host process)
+  reaches Docker via `DOCKER_NODES`, which **must** point at the colima socket, or
+  it dies with `Socket not found: /var/run/docker.sock`. See §6 and `env.example`.
 
 ---
 
@@ -200,10 +220,28 @@ mkdir /tmp/restore && tar xzf /tmp/restore.tgz -C /tmp/restore
 
 ---
 
-## 5. Remote access — Cloudflare Tunnel
+## 5. Remote access
 
 The api container publishes to `127.0.0.1:8080` (loopback only), so nothing is
-exposed except through the tunnel.
+exposed except through one of the paths below.
+
+### 5a. Tailscale Serve — private, tailnet-only (default)
+
+If the Mini is on your tailnet, this is the simplest path and keeps the UI off the
+public internet entirely. One-time: enable **HTTPS Certificates** for the tailnet
+(admin console → DNS), then:
+
+```sh
+tailscale serve --bg http://127.0.0.1:8080     # serves https://<host>.<tailnet>.ts.net (tailnet only)
+tailscale serve status                          # confirm the proxy
+```
+
+The api's own JWT sessions sit behind Tailscale device identity. Use **`serve`**
+(private); **`funnel`** would expose it publicly — do not use it here.
+
+### 5b. Cloudflare Tunnel — public hostname (optional)
+
+Only if you need access from outside the tailnet. Requires `cloudflared` (§0):
 
 ```sh
 cloudflared tunnel login
@@ -230,6 +268,19 @@ the project's linked GitHub origin, or reach `:2222` over LAN/Tailscale.
 
 ## 6. Colima notes & gotchas
 
+- **No `/var/run/docker.sock`; the dispatcher needs `DOCKER_NODES`.** bollard's
+  default socket path doesn't exist under colima, so the dispatcher exits with
+  `backend unavailable: Socket not found: /var/run/docker.sock`. Point it at the
+  colima socket in `chuggernaut.env` — and **quote the value**, because the env
+  file is `.`-sourced and the unquoted `|` separators are parsed as shell pipes
+  (`line NN: unix:///…: No such file or directory`):
+  ```sh
+  DOCKER_NODES="local|unix:///Users/<you>/.colima/default/docker.sock|4"
+  ```
+  Find the exact path with `colima status` (“docker socket: …”).
+- **`docker build --output` / `docker compose` errors** (`unknown flag: --output`,
+  `unknown shorthand flag: 'f'`) mean the buildx/compose CLI plugins aren't linked
+  — see the `~/.docker/cli-plugins` symlinks in §0.
 - **`host.docker.internal`** — agent containers reach NATS/sshd on the host via
   it. Smoke-test after first boot:
   `docker run --rm alpine sh -c 'nc -zv host.docker.internal 4222'`.

--- a/deploy/prod/build.sh
+++ b/deploy/prod/build.sh
@@ -7,6 +7,14 @@
 # in the image tag. Idempotent; safe to re-run from update.sh.
 set -eu
 
+# Preflight: the first build below uses BuildKit (`docker build --output`), which
+# needs the buildx CLI plugin. Fail with a pointer instead of a cryptic
+# "unknown flag: --output" (see deploy/prod/README.md §0 for the plugin symlink).
+if ! docker buildx version >/dev/null 2>&1; then
+  echo "build.sh: 'docker buildx' not found — link the buildx CLI plugin (README §0)" >&2
+  exit 1
+fi
+
 cd "$(dirname "$0")"                 # deploy/prod
 DEV="../dev"                          # dev Dockerfiles + sshd_config live here
 CTX="../.."                          # build context = workspace root

--- a/deploy/prod/env.example
+++ b/deploy/prod/env.example
@@ -6,7 +6,8 @@
 # the checkout location — do NOT set them here.
 
 # --- State lives OUTSIDE the git checkout so CI checkout / git pull never touch it.
-CHUG_DATA=/Users/worksalot/chuggernaut-data
+# Set CHUG_DATA to the DEPLOY USER's home (the account the launchd services run as).
+CHUG_DATA=/Users/<you>/chuggernaut-data
 KEYS_DIR=${CHUG_DATA}/keys
 REPOS_ROOT=${CHUG_DATA}/repos
 BACKUP_DEST=${CHUG_DATA}/backups
@@ -26,7 +27,14 @@ HOOK_BIN=/usr/local/bin/chuggernaut
 AGENT_PROVIDER_DEFAULT=claude
 AGENT_MODEL_DEFAULT=claude-sonnet-5
 
-# --- Docker fleet: unset DOCKER_NODES => single local socket, DOCKER_SLOTS lanes.
+# --- Docker fleet.
+# Linux with /var/run/docker.sock: leave DOCKER_NODES unset and just set DOCKER_SLOTS.
+# macOS + colima: there is NO /var/run/docker.sock, so you MUST set DOCKER_NODES to
+# the colima socket (find it via `colima status`), or the dispatcher dies with
+# "Socket not found: /var/run/docker.sock". QUOTE the value — the `|` separators are
+# shell pipes when this file is sourced. Extra nodes are comma-separated.
+#   DOCKER_NODES="local|unix:///Users/<you>/.colima/default/docker.sock|4"
+#   DOCKER_NODES="local|unix:///…/docker.sock|4, nuc|tcp://127.0.0.1:23751|4"
 DOCKER_SLOTS=4
 
 # --- API / UI


### PR DESCRIPTION
Folds the real snags hit during the first `gumbo-mini-0` production bootstrap into `deploy/prod` docs, so the next machine doesn't rediscover them.

## What & why
- **README §0** — `docker-buildx` + `docker-compose` (v2) are required (`build.sh` uses `docker build --output`; `boot.sh`/`update.sh` use `docker compose`). Homebrew installs them as standalone binaries, so add the `~/.docker/cli-plugins` symlinks. Also documents the **read-only deploy key** the deployed checkout needs to fetch `main`, and flags the colima-socket requirement.
- **README §5** — **Tailscale Serve** (private, tailnet-only) as the default remote-access path; Cloudflare Tunnel kept as the optional public path.
- **README §6 + env.example** — colima has no `/var/run/docker.sock`, so `DOCKER_NODES` must point at the colima socket **and be quoted** (the `|` separators are shell pipes when the env file is sourced).
- **build.sh** — preflight-checks `docker buildx` and fails with a pointer instead of a cryptic `unknown flag: --output`.
- **env.example** — `CHUG_DATA` as a `<you>` placeholder.

Docs + one shell preflight only — no Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)