### PR TITLE
feat(dogfood): install chuggernaut as a project on its own prod deployment

### DIFF
--- a/.claude/skills/chug/SKILL.md
+++ b/.claude/skills/chug/SKILL.md
@@ -9,27 +9,40 @@ You are interacting with a **live Chuggernaut v2 platform** on behalf of the
 user. Translate their input into API calls, execute them, and present the
 results clearly.
 
-## Auth — you act as `claude@dev.local`
+## Target — prod by default
 
-You authenticate **as a user, not as the platform**: a dedicated machine user
-(`claude@dev.local`) whose bearer token lives at
-`~/chuggernaut/deploy/dev/data/keys/claude.token`. Every action you take
-is attributed to that user and bounded by its roles — never use
-`dispatcher.creds` (the platform identity) for API work. On 401 the token
-has expired; re-mint it:
+The default target is the **prod deployment on gumbo-mini-0** (reached over
+the tailnet via Tailscale Serve):
 
 ```sh
-cd ~/chuggernaut/v2
-./target/release/chuggernaut admin --keys-dir deploy/dev/data/keys \
-  user token --email claude@dev.local > deploy/dev/data/keys/claude.token
+BASE=https://gumbo-mini-0.tail20c474.ts.net
+TOK=$(cat ~/.config/chuggernaut/gumbo.token)
+curl -s -H "Authorization: Bearer $TOK" $BASE/api/v1/projects | jq
 ```
 
-Every call:
+The dogfood project — chuggernaut developing itself — is
+**`kasofsk/chuggernaut`** (linked-origin: GitHub owns `main`, agents merge to
+`integration`, work ships as release PRs).
+
+If the user explicitly says **dev** (the local stack from `deploy/dev`):
+`BASE=http://localhost:8081`, token at `deploy/dev/data/keys/claude.token`.
+
+## Auth — you act as a user, not the platform
+
+Every action is attributed to the token's user and bounded by its roles —
+never use `dispatcher.creds` (the platform identity) for API work. On 401 the
+token has expired; re-mint:
 
 ```sh
-BASE=http://localhost:8081
-TOK=$(cat ~/chuggernaut/deploy/dev/data/keys/claude.token)
-curl -s -H "Authorization: Bearer $TOK" $BASE/api/v1/projects | jq
+# prod (minted on the Mini over ssh):
+ssh gumbo-mini-0 '~/chuggernaut/target/release/chuggernaut admin \
+  --keys-dir ~/chuggernaut-data/keys user token --email david@kasofsk.xyz \
+  --ttl 720h' > ~/.config/chuggernaut/gumbo.token
+
+# dev (minted locally):
+cd ~/chuggernaut
+./target/release/chuggernaut admin --keys-dir deploy/dev/data/keys \
+  user token --email claude@dev.local > deploy/dev/data/keys/claude.token
 ```
 
 ## Vocabulary
@@ -59,21 +72,25 @@ tasks).
 | `GET /api/v1/projects/{o}/{p}/tags` | knowledge tags (tags/*.md stems) |
 | `GET /api/v1/projects/{o}/{p}/tasks/pending` | human-task inbox |
 | `GET /api/v1/projects/{o}/{p}/events` (SSE) | live events; `.../jobs/{seq}/events` per job |
+| `GET /api/v1/projects/{o}/{p}/origin` | linked-origin status: release state, ahead_by, held |
 
 ### Write
 | Endpoint | Body | Effect |
 |---|---|---|
 | `POST /api/v1/projects` | `{owner, name}` | create project (platform admins; seeds the Code starter) |
+| `POST /api/v1/projects/link` | `{owner, name, origin_url, main_branch?}` | link an external GitHub origin (platform admins; needs CHUG_ORIGIN_* secrets set first) |
 | `POST /api/v1/projects/{o}/{p}/jobs` | `{type, title?, description?, deps?: [id], knowledge_tags?, eval?: [Evaluator]}` | create job (lands Frozen). description = the ticket; injected into work AND eval prompts |
 | `POST .../jobs/{seq}/release` | — | ▶ run the job |
 | `POST .../jobs/{seq}/revoke` | — | revoke (cascades to Frozen/Blocked/Ready dependents) |
 | `POST .../jobs/{seq}/tasks/{id}/resolve` | `{kind: "Pass"\|"Fail"\|"Escalation", structured, abort?, action?}` | resolve a human task; `abort: true` on an evaluator Fail = unfixable, escalate |
+| `POST /api/v1/projects/{o}/{p}/origin/release` | — | push integration → `chug/release-{n}` on the origin + open the PR; holds the merge queue (409: release open / gate in flight / nothing to release) |
+| `POST /api/v1/projects/{o}/{p}/origin/sync` | — | fetch origin + reconcile (merged PR → reset integration onto new main, clear hold) |
 
 ## Conventions
 
 - Refer to jobs as `#N`; numbers are per-project and monotonic.
 - **Creating a job does not start it** — release ("run") is separate. Release
-  releases real agent containers (spends tokens): only do it when the user
+  launches real agent containers (spends tokens): only do it when the user
   clearly asked to run, otherwise create and tell them it's ready to run.
 - Write job descriptions like tickets: what to build, constraints,
   acceptance criteria. The work agent and its reviewer both see it verbatim.
@@ -81,9 +98,14 @@ tasks).
   with `curl -N --max-time 30`. `channel-update` events are the agent
   narrating its own progress.
 - Revoke kills running containers — confirm with the user first.
+- **Origin release/merge**: `origin/release` opens a GitHub PR the user
+  reviews and merges; merging redeploys the platform (CD on green main), so
+  don't trigger a release while jobs are mid-Work, and confirm before
+  calling it.
 - Presenting: job lists as compact tables (#, title, state, type); job detail
   as state + title + tasks summary; don't dump raw JSON unless asked.
-- If the API is unreachable, say so and suggest checking that the dispatcher
-  and api processes are up (see `deploy/dev/README.md` "Run").
+- If the API is unreachable: for prod check Tailscale is up and the Mini's
+  stack is running (`deploy/prod/README.md`); for dev see
+  `deploy/dev/README.md` "Run".
 - For dispatcher internals beyond the API, read `~/chuggernaut/spec.md`
   and `progress.md` rather than guessing.

--- a/deploy/prod/Dockerfile.agent-rust
+++ b/deploy/prod/Dockerfile.agent-rust
@@ -1,0 +1,31 @@
+# Rust agent image for the chuggernaut-on-chuggernaut dogfood project
+# (jobs/code.yaml `image:`): full Rust toolchain + the claude CLI. Built with
+# the repo root as context so the workspace's crate dependencies can be baked
+# in — spec §11 defers per-project build caches to future work; the v1 answer
+# is to bake toolchain and dependencies into the declared image.
+FROM rust:1.96-bookworm
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git openssh-client ripgrep jq ca-certificates curl \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN rustup component add rustfmt clippy \
+ && npm install -g @anthropic-ai/claude-code
+
+# Pre-warm the crates.io index + .crate downloads into CARGO_HOME so per-job
+# builds skip the network fetch. The layer invalidates when sources change;
+# the compile itself is still cold per container (no cross-job cache in v1).
+COPY Cargo.toml Cargo.lock /prewarm/
+COPY crates /prewarm/crates
+RUN cd /prewarm && cargo fetch --locked && rm -rf /prewarm
+
+# Headless agents run as root inside a disposable container; IS_SANDBOX lets
+# `--dangerously-skip-permissions` through the CLI's root check.
+ENV IS_SANDBOX=1
+
+# The clone happens as root at /workspace; commits need an identity.
+RUN git config --system user.name "Chuggernaut Agent" \
+ && git config --system user.email "agent@chuggernaut.local" \
+ && git config --system --add safe.directory '*'

--- a/deploy/prod/README.md
+++ b/deploy/prod/README.md
@@ -8,7 +8,12 @@ agent containers as siblings. Deployed **automatically on every green `main`** v
 the Mini's GitHub self-hosted runner, and **backed up hourly to Cloudflare R2**.
 
 Chuggernaut itself is still developed on the laptop and pushed to GitHub; the Mini
-only *consumes* `main`.
+only *consumes* `main`. Since the dogfood project link (`kasofsk/chuggernaut`),
+finished agent work also flows *back* to GitHub as `chug/release-{n}` PRs.
+
+- **Deploy user**: the launchd services and all state run under the Mini's local
+  account **`worksalot`** — that's the `<you>`/`$CHUG_DATA` user throughout this
+  runbook, and the username for Tailscale SSH (`ssh worksalot@gumbo-mini-0`).
 
 - **State lives outside the checkout** at `~/chuggernaut-data/{keys,repos,backups}`
   (+ the `nats-data` Docker volume), so a `git checkout`/deploy never touches it.

--- a/deploy/prod/build.sh
+++ b/deploy/prod/build.sh
@@ -32,7 +32,11 @@ docker build -f "$DEV/Dockerfile.ssh" --build-arg "GIT_UID=$GIT_UID" \
 # Agent image the job types run in.
 docker build -f "$DEV/Dockerfile.agent" -t "chuggernaut/agent:$TAG" "$DEV"
 
+# Rust agent image for the chuggernaut dogfood project (repo-root context —
+# it bakes a cargo prefetch of the workspace deps).
+docker build -f Dockerfile.agent-rust -t "chuggernaut/agent-rust:$TAG" "$CTX"
+
 # API service image (HTTP↔NATS bridge + web UI baked in).
 docker build -f Dockerfile.api -t "chuggernaut/api:$TAG" "$CTX"
 
-echo "built chuggernaut/{ssh,agent,api}:$TAG; channel -> $(pwd)/out/chuggernaut-channel"
+echo "built chuggernaut/{ssh,agent,agent-rust,api}:$TAG; channel -> $(pwd)/out/chuggernaut-channel"

--- a/jobs/_defaults.yaml
+++ b/jobs/_defaults.yaml
@@ -1,0 +1,6 @@
+# Appended to every job type's eval list (spec §1.1) — the evergreen CI gate.
+eval:
+  - name: ci
+    type: command
+    image: chuggernaut/agent-rust:prod
+    run: ./tasks/ci.sh

--- a/jobs/code.yaml
+++ b/jobs/code.yaml
@@ -1,0 +1,23 @@
+# Chuggernaut-on-Chuggernaut: a coding agent implements the ticket inside the
+# Rust workspace, an inline reviewer (fresh session each round, spec §4.5)
+# pushes back before submit, and the project-wide CI gate in
+# jobs/_defaults.yaml judges the result.
+name: code
+display_name: Code
+description: Implement the job ticket in the chuggernaut Rust workspace; inline review, CI-gated.
+image: chuggernaut/agent-rust:prod
+work:
+  type: agent
+  prompt: prompts/work/code.md
+  review:
+    prompt: prompts/review/code.md
+    iterations: 3
+resources:
+  cpu: 3
+  memory: 5g
+  # Covers the whole inline loop — all author/review iterations in one
+  # container — plus a cold cargo build of the workspace.
+  task_timeout: 1h
+work_retries: 1
+eval_retries: 1
+rework_budget: 2

--- a/prompts/review/code.md
+++ b/prompts/review/code.md
@@ -1,0 +1,23 @@
+# Inline review
+
+You are the inline reviewer (fresh session — you have no memory of prior
+rounds). The working tree carries a change that claims to implement the
+**Job Brief** appended below. This repository is the chuggernaut platform
+itself; its conventions are in `CLAUDE.md` (single-writer dispatcher, `store`
+is the only crate that talks to NATS, `types` stays pure data) — flag
+violations of those as findings.
+
+1. Read the brief, then review the diff against the base branch
+   (`git diff $BASE_BRANCH...HEAD`, or `git log -p` on this branch).
+2. Judge: does the change implement the brief correctly and completely,
+   without breaking or needlessly touching unrelated code? Does new behavior
+   come with a regression test at the right tier (`testing.md`)?
+3. Publish your verdict with the `submit_review` tool — required before exit:
+   - Implemented correctly → `{ "pass": true }`.
+   - Fixable problems → `{ "pass": false, "findings": [ { "file": "...",
+     "issue": "...", "suggestion": "..." } ] }`. The author is re-invoked
+     with your findings verbatim — make them actionable.
+4. Exit 0.
+
+Your verdict is advisory — the outer CI evaluator is the gate. Do not commit
+or push.

--- a/prompts/work/code.md
+++ b/prompts/work/code.md
@@ -1,0 +1,39 @@
+# Implement the ticket
+
+You are working **on the chuggernaut codebase itself** — the platform running
+you. The work to do is described in the **Job Brief** section appended below.
+If there is no Job Brief, call `submit_result` with a summary explaining that
+no ticket was provided, and exit non-zero.
+
+Before writing code, orient yourself — don't re-derive what's documented:
+
+- `CLAUDE.md` — conventions that bite if missed (single-writer dispatcher,
+  `store` is the only NATS crate, `types` is pure data).
+- `spec.md` — normative behavior; `crates.md` — which crate owns what;
+  `testing.md` — which tier a new test belongs in.
+
+Then:
+
+1. Implement what the brief describes, following the existing code style and
+   structure of this repository. New behavior lands with a regression test at
+   the lowest tier that can express it.
+2. Keep the change minimal and focused — do not refactor unrelated code.
+3. Before submitting, run what the CI evaluator will run (`tasks/ci.sh`):
+   `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
+   and `cargo test --workspace`. Tests that need NATS or Docker self-skip in
+   this container ("skipping: Docker daemon unavailable") — that is expected;
+   do not chase them.
+4. Commit your work to the current branch (you are already on the job
+   branch) with clear commit messages, and push.
+5. Narrate as you go with the `update_status` tool — this streams live to
+   the operator's screen. Call it at least three times: right after reading
+   the brief (`update_status("plan: ...")`, one line), after each meaningful
+   step (file written, tests run), and just before you submit.
+6. When done, call `submit_result` with:
+   - `summary`: one paragraph describing what you built (this becomes the
+     merge commit body),
+   - `structured`: `{ "files_changed": [...], "notes": "..." }`.
+7. Exit 0.
+
+An inline reviewer will judge your change against the same brief; if it finds
+problems you will be re-invoked with its findings.

--- a/tasks/ci.sh
+++ b/tasks/ci.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Project-wide CI gate (wired in jobs/_defaults.yaml). Mirrors
+# .github/workflows/ci.yml. Runs inside the agent container: NATS/Docker
+# integration tests self-skip there (require_nats! in test-utils).
+set -eu
+export CARGO_TERM_COLOR=always
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace

--- a/tasks/review-code.md
+++ b/tasks/review-code.md
@@ -1,0 +1,24 @@
+# Review the change
+
+You are an independent code reviewer. The current branch carries a change
+that claims to implement the **Job Brief** appended below.
+
+1. Call `update_status("reviewing: <one line on what you are checking>")` —
+   it streams to the operator. Read the brief, then review the diff against
+   the base branch
+   (`git diff $BASE_BRANCH...HEAD`, or `git log -p` on this branch).
+2. Judge: does the change implement the brief correctly and completely,
+   without breaking or needlessly touching unrelated code?
+3. Publish your verdict with the `submit_eval` tool — required before exit:
+   - Implemented correctly → `pass: true`, with
+     `structured: { "notes": "..." }`.
+   - Fixable problems → `pass: false`, with
+     `structured: { "findings": [ { "file": "...", "issue": "...",
+     "suggestion": "..." } ] }`. The author agent is re-invoked with your
+     findings verbatim — make them actionable.
+   - The brief cannot be satisfied by rework (contradictory or impossible
+     requirements) → `pass: false, abort: true`, with the reason in
+     `structured`. This skips further rework and escalates to a human.
+4. Exit 0.
+
+You have read-only repository access; do not attempt to commit or push.


### PR DESCRIPTION
Dogfooding: make this repo a chuggernaut **linked-origin project** on gumbo-mini-0, so chuggernaut agent jobs can develop chuggernaut itself. GitHub keeps owning `main`; agents merge to an internal `integration` branch and finished work ships back here as `chug/release-{n}` PRs.

Project-owned config (spec §1.1, §5.3):

- `jobs/code.yaml` — agent work type with inline review (spec §4.5), sized for cold cargo builds on the Mini (3 cpu / 5g / 1h loop timeout)
- `jobs/_defaults.yaml` + `tasks/ci.sh` — project-wide CI gate mirroring `.github/workflows/ci.yml`; NATS/Docker integration tests self-skip inside agent containers (`require_nats!`)
- `prompts/work/code.md` / `prompts/review/code.md` — chuggernaut-specific author + inline-reviewer prompts; `tasks/review-code.md` committed verbatim from the starter template so the link-time skip-existing seed injects nothing
- `deploy/prod/Dockerfile.agent-rust` (+ `build.sh`) — `rust:1.96-bookworm` + claude CLI agent image with the workspace's crate deps prefetched (`cargo fetch --locked`); v1 has no cross-job build cache, deps are baked into the image per spec §11
- `.claude/skills/chug` — defaults to the prod API on gumbo-mini-0 (Tailscale Serve), keeps the dev stack as an explicit alternative, adds the linked-origin `origin/release` / `origin/sync` verbs

After merge + CD: set `CHUG_ORIGIN_DEPLOY_KEY`/`CHUG_ORIGIN_PAT` project secrets on the Mini, `admin project link --owner kasofsk --name chuggernaut`, then smoke-test a job end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)