### PR TITLE
fix(dogfood): memory limit format 5g -> 5Gi in jobs/code.yaml

### DIFF
--- a/jobs/code.yaml
+++ b/jobs/code.yaml
@@ -14,7 +14,7 @@ work:
     iterations: 3
 resources:
   cpu: 3
-  memory: 5g
+  memory: 5Gi
   # Covers the whole inline loop — all author/review iterations in one
   # container — plus a cold cargo build of the workspace.
   task_timeout: 1h


### PR DESCRIPTION
Found by smoke job #1: `parse_memory` accepts only `Ki/Mi/Gi` or plain bytes, so the eval container never launched and the job wedged in Evaluation. One-line config fix; the two underlying platform bugs (validation gap in `types`, eval task stuck Running on launch failure) are filed as dogfood jobs on the platform itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)