### PR TITLE
feat(prod): gumbo-nuc-0 worker node — tunnel, worker-arch builds, fleet config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ web/dist/
 # prod deploy — local secrets, rendered artifacts, deploy marker
 deploy/prod/chuggernaut.env
 deploy/prod/out/
+deploy/prod/out-nuc/
 deploy/prod/rclone.conf
 deploy/prod/*.local
 .deployed-sha

--- a/deploy/prod/README.md
+++ b/deploy/prod/README.md
@@ -73,7 +73,7 @@ Also:
   ```
 - **Colima has no `/var/run/docker.sock`** — the dispatcher (a native host process)
   reaches Docker via `DOCKER_NODES`, which **must** point at the colima socket, or
-  it dies with `Socket not found: /var/run/docker.sock`. See §6 and `env.example`.
+  it dies with `Socket not found: /var/run/docker.sock`. See §7 and `env.example`.
 
 ---
 
@@ -137,6 +137,7 @@ Create projects with `chug admin project create --owner <o> --name <n> --repos-r
 |---|---|---|
 | `com.chuggernaut.boot` | RunAtLoad | `boot.sh`: colima + compose (nats/ssh/api) + wait-for-NATS |
 | `com.chuggernaut.dispatcher` | KeepAlive | `run-dispatcher.sh` (the only host service) |
+| `com.chuggernaut.nuc-tunnel` | KeepAlive | SSH tunnel to the worker's Docker socket (see "Worker nodes") |
 | `com.chuggernaut.backup-hourly` | :00 hourly | `backup-r2.sh` |
 | `com.chuggernaut.backup-daily` | 03:20 | `backup-r2.sh promote daily` |
 | `com.chuggernaut.backup-monthly` | 1st 03:40 | `backup-r2.sh promote monthly` |
@@ -279,7 +280,47 @@ the project's linked GitHub origin, or reach `:2222` over LAN/Tailscale.
 
 ---
 
-## 6. Colima notes & gotchas
+## 6. Worker nodes (gumbo-nuc-0)
+
+Job containers run on a dedicated worker so heavy cargo builds never starve the
+dispatcher node. The prod fleet is **worker-only**: the Mini's colima node is
+registered at **0 slots** (placement never picks it; failback = bump the slots
+and restart the dispatcher), and all work/eval containers land on
+**gumbo-nuc-0** (12-core/31GiB, x86_64, NixOS, Docker preinstalled).
+
+**How it hangs together** (all pieces ship in this repo):
+
+- **Tunnel** — `com.chuggernaut.nuc-tunnel` (launchd, KeepAlive) forwards
+  `127.0.0.1:23751` → the nuc's `/run/docker.sock` over SSH, using the
+  dedicated key `~/.ssh/nuc_tunnel` (public half in the nuc's
+  `~/.ssh/authorized_keys`; on NixOS consider pinning it in configuration.nix).
+  bollard only speaks `unix://`/plaintext `tcp://` — the tunnel keeps the
+  daemon off the network (no mTLS yet, spec §3.1 TODO).
+- **Fleet** — in `chuggernaut.env`:
+  `DOCKER_NODES="local|unix:///…/colima/…/docker.sock|0, nuc|tcp://127.0.0.1:23751|4"`
+  plus `WORKER_DOCKER_HOST=tcp://127.0.0.1:23751`.
+- **Cross-node addressing** — containers on the nuc reach the Mini's NATS and
+  git front via the Mini's **tailnet IP**, not `host.docker.internal`:
+  `NATS_URL_CONTAINER=nats://100.116.243.42:4222`,
+  `REPO_URL_BASE=ssh://git@100.116.243.42:2222` (ports 4222/2222 are published
+  on all interfaces by compose).
+- **Arch split** — the Mini is arm64, the nuc x86_64. `build-worker.sh`
+  (called by `update.sh`; no-op when `WORKER_DOCKER_HOST` is unset) builds
+  `chuggernaut/agent{,-rust}:prod` natively on the nuc's daemon and extracts a
+  **worker-arch** channel binary to `deploy/prod/out-nuc/`;
+  `run-dispatcher.sh` injects that one instead of `out/` when a worker is
+  configured.
+- **Boot coupling** — the dispatcher's startup `ping_all` hard-fails if any
+  fleet node is unreachable, so the tunnel is boot-critical (KeepAlive
+  mitigates; graceful degradation is filed as a dogfood job). CD deploys also
+  need the tunnel up for the worker builds.
+- **Verify placement** — during a job: `ssh worksalot@gumbo-nuc-0 docker ps`
+  shows the work/eval containers; the Mini's colima shows none
+  (`docker ps --filter label=chuggernaut.managed`).
+
+---
+
+## 7. Colima notes & gotchas
 
 - **No `/var/run/docker.sock`; the dispatcher needs `DOCKER_NODES`.** bollard's
   default socket path doesn't exist under colima, so the dispatcher exits with

--- a/deploy/prod/build-worker.sh
+++ b/deploy/prod/build-worker.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Build the agent images + channel binary for a REMOTE worker node, via its
+# (SSH-tunneled) Docker endpoint. The worker may be a different architecture
+# than the Mini — images build natively on its daemon, and the channel binary
+# artifacts stage writes a worker-arch binary back to deploy/prod/out-nuc/
+# (the dispatcher injects those bytes into every container it launches there;
+# run-dispatcher.sh prefers out-nuc when it exists).
+#
+# No-ops cleanly when WORKER_DOCKER_HOST is unset (single-node deploys).
+# Called from update.sh after the env is loaded; runnable by hand:
+#   WORKER_DOCKER_HOST=tcp://127.0.0.1:23751 deploy/prod/build-worker.sh
+set -eu
+
+if [ -z "${WORKER_DOCKER_HOST:-}" ]; then
+  echo "build-worker: WORKER_DOCKER_HOST unset — no worker node; skipping"
+  exit 0
+fi
+
+cd "$(dirname "$0")"                 # deploy/prod
+DEV="../dev"
+CTX="../.."                          # build context = workspace root
+TAG="${CHUG_IMAGE_TAG:-prod}"
+
+export DOCKER_HOST="$WORKER_DOCKER_HOST"
+
+# Worker-arch channel binary, written back through the tunnel to the Mini.
+docker build -f "$DEV/Dockerfile.ssh" --target artifacts \
+  --output type=local,dest=out-nuc "$CTX"
+
+# Agent images the job types run in, native on the worker's daemon.
+docker build -f "$DEV/Dockerfile.agent" -t "chuggernaut/agent:$TAG" "$DEV"
+docker build -f Dockerfile.agent-rust -t "chuggernaut/agent-rust:$TAG" "$CTX"
+
+echo "build-worker: chuggernaut/{agent,agent-rust}:$TAG on $WORKER_DOCKER_HOST; channel -> $(pwd)/out-nuc/chuggernaut-channel"

--- a/deploy/prod/env.example
+++ b/deploy/prod/env.example
@@ -16,9 +16,13 @@ BACKUP_DEST=${CHUG_DATA}/backups
 # The dispatcher/api reach NATS on the host's published port.
 NATS_URL=nats://localhost:4222
 # The URL injected into agent containers — must be reachable from inside them.
+# Single-node (all containers on this machine): host.docker.internal works.
+# With a REMOTE worker node it does not (it resolves to the worker itself) —
+# use this machine's tailnet IP instead, e.g. nats://100.x.y.z:4222.
 NATS_URL_CONTAINER=nats://host.docker.internal:4222
 
 # --- Git front (SSH). Clone URL injected into agent containers; never localhost.
+# Same remote-worker rule as NATS_URL_CONTAINER: tailnet IP when a worker exists.
 REPO_URL_BASE=ssh://git@host.docker.internal:2222
 # Pre-receive hook path as seen INSIDE the ssh container.
 HOOK_BIN=/usr/local/bin/chuggernaut
@@ -35,7 +39,18 @@ AGENT_MODEL_DEFAULT=claude-sonnet-5
 # shell pipes when this file is sourced. Extra nodes are comma-separated.
 #   DOCKER_NODES="local|unix:///Users/<you>/.colima/default/docker.sock|4"
 #   DOCKER_NODES="local|unix:///…/docker.sock|4, nuc|tcp://127.0.0.1:23751|4"
+# Worker-only fleet (README "Worker nodes"): keep the local node registered at
+# 0 slots so placement never picks it but failback is a one-line edit:
+#   DOCKER_NODES="local|unix:///…/docker.sock|0, nuc|tcp://127.0.0.1:23751|4"
 DOCKER_SLOTS=4
+
+# --- Remote worker node (optional; README "Worker nodes").
+# The worker's Docker endpoint as seen FROM THIS machine (the SSH-tunneled
+# port from com.chuggernaut.nuc-tunnel). When set, update.sh/build-worker.sh
+# build the agent images + a worker-arch channel binary (deploy/prod/out-nuc/)
+# on that daemon, and run-dispatcher.sh injects the out-nuc channel binary.
+# Leave unset on single-node deploys.
+#WORKER_DOCKER_HOST=tcp://127.0.0.1:23751
 
 # --- API / UI
 # The api runs as a compose container (deploy/prod/Dockerfile.api) with the web

--- a/deploy/prod/launchd/com.chuggernaut.nuc-tunnel.plist.template
+++ b/deploy/prod/launchd/com.chuggernaut.nuc-tunnel.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Rendered by install-launchd.sh: @REPO@ -> checkout, @HOME@ -> $HOME. -->
+<!-- SSH tunnel exposing the gumbo-nuc-0 worker's Docker socket on
+     127.0.0.1:23751 (the tcp:// endpoint in DOCKER_NODES). KeepAlive: the
+     dispatcher refuses to start if any fleet node is unreachable, so this
+     tunnel is boot-critical (see README "Worker nodes"). -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.chuggernaut.nuc-tunnel</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/ssh</string>
+    <string>-N</string>
+    <string>-i</string><string>@HOME@/.ssh/nuc_tunnel</string>
+    <string>-o</string><string>IdentitiesOnly=yes</string>
+    <string>-o</string><string>BatchMode=yes</string>
+    <string>-o</string><string>ExitOnForwardFailure=yes</string>
+    <string>-o</string><string>ServerAliveInterval=30</string>
+    <string>-o</string><string>ServerAliveCountMax=3</string>
+    <string>-o</string><string>StrictHostKeyChecking=accept-new</string>
+    <string>-L</string><string>127.0.0.1:23751:/run/docker.sock</string>
+    <string>worksalot@gumbo-nuc-0</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>10</integer>
+  <key>StandardOutPath</key><string>@HOME@/Library/Logs/chuggernaut/nuc-tunnel.log</string>
+  <key>StandardErrorPath</key><string>@HOME@/Library/Logs/chuggernaut/nuc-tunnel.log</string>
+</dict>
+</plist>

--- a/deploy/prod/run-dispatcher.sh
+++ b/deploy/prod/run-dispatcher.sh
@@ -10,7 +10,14 @@ set -a
 set +a
 
 # Repo-relative paths are derived here, not stored in the env file.
-export CHANNEL_BINARY="$HERE/out/chuggernaut-channel"
+# With a remote worker fleet (WORKER_DOCKER_HOST set), job containers run on
+# the worker, so inject the worker-arch channel binary built by
+# build-worker.sh; otherwise the local (colima-arch) one from build.sh.
+if [ -n "${WORKER_DOCKER_HOST:-}" ] && [ -f "$HERE/out-nuc/chuggernaut-channel" ]; then
+  export CHANNEL_BINARY="$HERE/out-nuc/chuggernaut-channel"
+else
+  export CHANNEL_BINARY="$HERE/out/chuggernaut-channel"
+fi
 
 "$HERE/wait-nats.sh"
 exec "$REPO/target/release/chuggernaut" dispatcher

--- a/deploy/prod/update.sh
+++ b/deploy/prod/update.sh
@@ -58,6 +58,10 @@ set -a
 . deploy/prod/chuggernaut.env
 set +a
 
+# 3. Worker-node images + worker-arch channel binary (no-op when
+#    WORKER_DOCKER_HOST is unset — see deploy/prod/build-worker.sh).
+CHUG_IMAGE_TAG="${CHUG_IMAGE_TAG:-prod}" deploy/prod/build-worker.sh
+
 # 4. Idempotent init — creates only missing keys (e.g. a newly-added age key).
 target/release/chuggernaut init --keys-dir "$KEYS_DIR" --repos-root "$REPOS_ROOT"
 


### PR DESCRIPTION
Moves all job containers to gumbo-nuc-0 (12c/31GiB amd64) so cargo-heavy work never starves the dispatcher node — motivated by today's disk/IO incident on the Mini.

- `com.chuggernaut.nuc-tunnel` launchd template: KeepAlive SSH tunnel, `127.0.0.1:23751` → nuc `/run/docker.sock` (bollard has no ssh:// or mTLS; tunnel keeps the daemon off the network)
- `build-worker.sh` (+ `update.sh` step 3): agent images built natively on the worker daemon, worker-arch channel binary extracted to `out-nuc/` — handles the arm64 Mini / amd64 nuc split; no-op when `WORKER_DOCKER_HOST` unset
- `run-dispatcher.sh`: injects the `out-nuc` channel binary when a worker is configured
- `env.example`: worker-only fleet form (`local|…|0, nuc|tcp://127.0.0.1:23751|4`), tailnet-IP guidance for `NATS_URL_CONTAINER`/`REPO_URL_BASE`, `WORKER_DOCKER_HOST`
- README: new 'Worker nodes' §6 (topology, arch split, boot-coupling caveat)

Live env/ops changes on the Mini follow after merge (fleet env edit + dispatcher restart). Fleet resilience (start with a node down) and per-type placement pins are filed as dogfood job #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)