### PR TITLE
chug release 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.18",
  "tokio",
+ "types",
 ]
 
 [[package]]

--- a/crates/container/Cargo.toml
+++ b/crates/container/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+types.workspace = true
 async-trait.workspace = true
 bollard = "0.19"
 futures.workspace = true

--- a/crates/container/src/docker.rs
+++ b/crates/container/src/docker.rs
@@ -375,22 +375,11 @@ fn build_tar(files: &[InjectedFile]) -> Result<Vec<u8>, String> {
     builder.into_inner().map_err(|e| e.to_string())
 }
 
-/// Parse "512Mi" / "4Gi" / plain bytes into bytes.
+/// Parse "512Mi" / "4Gi" / plain bytes into bytes. The accepted grammar is
+/// owned by `types` so field-rules validation rejects a bad limit offline
+/// (`chuggernaut validate`) before it ever reaches this launch-time parse.
 fn parse_memory(s: &str) -> Result<i64, String> {
-    let s = s.trim();
-    let (num, mult) = if let Some(n) = s.strip_suffix("Ki") {
-        (n, 1024i64)
-    } else if let Some(n) = s.strip_suffix("Mi") {
-        (n, 1024 * 1024)
-    } else if let Some(n) = s.strip_suffix("Gi") {
-        (n, 1024 * 1024 * 1024)
-    } else {
-        (s, 1)
-    };
-    num.trim()
-        .parse::<i64>()
-        .map(|v| v * mult)
-        .map_err(|_| format!("invalid memory limit {s:?}"))
+    types::parse_memory(s).map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -403,6 +392,24 @@ mod tests {
         assert_eq!(parse_memory("512Mi").unwrap(), 512 * 1024 * 1024);
         assert_eq!(parse_memory("1048576").unwrap(), 1_048_576);
         assert!(parse_memory("4GB").is_err());
+    }
+
+    /// Pin the launch-time parse to the `types` field-rules grammar: every case
+    /// must resolve identically (ok→same bytes, err→err) in both crates, so a
+    /// limit that passes `chuggernaut validate` can never be rejected at launch
+    /// (the dogfood `5g` bug) and vice-versa.
+    #[test]
+    fn parse_memory_agrees_with_types_grammar() {
+        for case in [
+            "5Gi", "512Mi", "4Ki", "1048576", // legal
+            "5g", "4GB", "", "  ", "-5", "0", "1.5Gi", "Gi", "5gi", // illegal
+        ] {
+            assert_eq!(
+                parse_memory(case).ok(),
+                types::parse_memory(case).ok(),
+                "launch-time parse and types validation disagree on {case:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/dispatcher/src/escalation.rs
+++ b/crates/dispatcher/src/escalation.rs
@@ -26,6 +26,7 @@ pub fn escalation_task(
         session_id: None,
         attempt: 1,
         evaluator: None,
+        stage: 0,
         container_id: None,
         result: None,
         created_at: Utc::now(),

--- a/crates/dispatcher/src/eval.rs
+++ b/crates/dispatcher/src/eval.rs
@@ -12,14 +12,64 @@ use crate::exec::{ChannelRole, eval_image, task_timeout};
 use agent::AgentRunConfig;
 use chrono::Utc;
 use container::{ContainerLaunchConfig, bootstrap_cmd};
+use std::collections::VecDeque;
 use types::{
     EvalResult, Evaluator, EvaluatorType, JobState, Task, TaskKind, TaskPhase, TaskResult,
     TaskState, WorkType, WrapUpMode,
 };
 use vcs::MergeOutcome;
 
+/// One cycle's evaluation, run as an ascending sequence of stages (spec §3.3
+/// staged evaluation). Only the current stage has live tasks: `slots` is the
+/// stage in flight, `pending` the stages not yet created, `done` the outcomes
+/// of stages that already completed and passed. The reduce folds `done` and
+/// `slots` together. A single-stage round leaves `pending`/`done` empty and is
+/// byte-for-byte the unstaged behavior; the merge gate always builds one.
 pub struct EvalRound {
     pub slots: Vec<EvalSlot>,
+    /// Evaluators for stages not yet launched, grouped ascending by `stage`.
+    pub pending: VecDeque<Vec<Evaluator>>,
+    /// Slots from earlier stages that completed and let the round advance.
+    pub done: Vec<EvalSlot>,
+}
+
+impl EvalRound {
+    /// A single-stage round: the merge gate, and the compatibility shape for a
+    /// job whose evaluators all share one stage.
+    pub fn single(slots: Vec<EvalSlot>) -> Self {
+        EvalRound {
+            slots,
+            pending: VecDeque::new(),
+            done: Vec::new(),
+        }
+    }
+}
+
+/// Partition evaluators into stages in ascending `stage` order, preserving the
+/// declared order within a stage (stable sort). One distinct stage → one group,
+/// which is exactly today's single fan-out.
+pub(crate) fn group_stages(mut evaluators: Vec<Evaluator>) -> VecDeque<Vec<Evaluator>> {
+    evaluators.sort_by_key(|e| e.stage);
+    let mut stages: VecDeque<Vec<Evaluator>> = VecDeque::new();
+    for e in evaluators {
+        match stages.back_mut() {
+            Some(last) if last[0].stage == e.stage => last.push(e),
+            _ => stages.push_back(vec![e]),
+        }
+    }
+    stages
+}
+
+/// Whether a completed stage lets the next stage start: every *required*
+/// evaluator resolved to a product `pass: true`. A required product fail, an
+/// abort (which implies `pass: false`), or an infra failure closes the round —
+/// later stages are not created. Advisory (`required: false`) outcomes never
+/// block progression.
+pub(crate) fn stage_passed(slots: &[EvalSlot]) -> bool {
+    slots.iter().all(|s| {
+        !s.evaluator.required.unwrap_or(true)
+            || matches!(s.outcome, Some(SlotOutcome::Product { pass: true, .. }))
+    })
 }
 
 pub struct EvalSlot {
@@ -86,7 +136,33 @@ impl Core {
             return self.finalize_pass(owner, project, seq).await;
         }
 
+        // Staged fan-out (§3.3): launch stage 0 now, hold the rest until each
+        // prior stage passes. A single-stage job launches everything at once.
         let branch = job.branch.clone();
+        let mut pending = group_stages(evaluators);
+        let first = pending.pop_front().expect("non-empty evaluators");
+        let slots = self
+            .launch_eval_stage(owner, project, seq, &branch, cycle, first)
+            .await?;
+        self.active.get_mut(&key).expect("exec state").round = Some(EvalRound {
+            slots,
+            pending,
+            done: Vec::new(),
+        });
+        Ok(())
+    }
+
+    /// Fan out one stage's evaluators against the job branch (§3.3). Returns the
+    /// live slots; the caller installs them on the round.
+    pub(crate) async fn launch_eval_stage(
+        &mut self,
+        owner: &str,
+        project: &str,
+        seq: u64,
+        branch: &str,
+        cycle: u32,
+        evaluators: Vec<Evaluator>,
+    ) -> Result<Vec<EvalSlot>> {
         let mut slots = Vec::new();
         for evaluator in evaluators {
             let task_id = self
@@ -95,7 +171,7 @@ impl Core {
                     project,
                     seq,
                     TaskPhase::Evaluation,
-                    &branch,
+                    branch,
                     cycle,
                     &evaluator,
                     1,
@@ -108,8 +184,7 @@ impl Core {
                 outcome: None,
             });
         }
-        self.active.get_mut(&key).expect("exec state").round = Some(EvalRound { slots });
-        Ok(())
+        Ok(slots)
     }
 
     /// Create + launch one evaluator task (§3.3 evaluator types). Shared by the
@@ -183,6 +258,7 @@ impl Core {
             },
             attempt,
             evaluator: Some(evaluator.name.clone()),
+            stage: evaluator.stage,
             container_id: None,
             session_id: session_id.clone(),
             result: None,
@@ -198,7 +274,7 @@ impl Core {
             "task-created",
             serde_json::json!({
                 "task_id": task_id, "phase": phase_name, "cycle": cycle,
-                "attempt": attempt, "evaluator": evaluator.name,
+                "attempt": attempt, "evaluator": evaluator.name, "stage": evaluator.stage,
             }),
         )
         .await?;
@@ -431,10 +507,7 @@ impl Core {
             abort,
             structured,
         });
-        if round.slots.iter().all(|s| s.outcome.is_some()) {
-            return self.reduce(owner, project, seq).await;
-        }
-        Ok(())
+        self.stage_complete(owner, project, seq).await
     }
 
     /// Eval container exited. The verdict source depends on the type: command
@@ -574,10 +647,59 @@ impl Core {
         if let Some(outcome) = outcome {
             let round = self.active.get_mut(&key).unwrap().round.as_mut().unwrap();
             round.slots[slot_idx].outcome = Some(outcome);
-            if round.slots.iter().all(|s| s.outcome.is_some()) {
-                return self.reduce(owner, project, seq).await;
-            }
+            return self.stage_complete(owner, project, seq).await;
         }
+        Ok(())
+    }
+
+    /// Called whenever a slot in the current stage resolves. A no-op while the
+    /// stage is still in flight. Once every slot in the stage is terminal:
+    /// advance to the next stage when every *required* evaluator passed and a
+    /// later stage remains (§3.3 staged evaluation); otherwise run the reduce
+    /// over every stage that ran. A short-circuited stage leaves the pending
+    /// stages uncreated — they simply have no task records for this cycle.
+    pub(crate) async fn stage_complete(
+        &mut self,
+        owner: &str,
+        project: &str,
+        seq: u64,
+    ) -> Result<()> {
+        let key = (owner.to_string(), project.to_string(), seq);
+        let (complete, advance) = {
+            let Some(round) = self.active.get(&key).and_then(|e| e.round.as_ref()) else {
+                return Ok(());
+            };
+            let complete = round.slots.iter().all(|s| s.outcome.is_some());
+            (
+                complete,
+                complete && stage_passed(&round.slots) && !round.pending.is_empty(),
+            )
+        };
+        if !complete {
+            return Ok(());
+        }
+        if !advance {
+            return self.reduce(owner, project, seq).await;
+        }
+        // Fold the finished stage into `done` and fan out the next one.
+        let branch = self.must_get(owner, project, seq)?.branch.clone();
+        let cycle = self.active.get(&key).expect("exec state").cycle;
+        let next = self
+            .active
+            .get_mut(&key)
+            .unwrap()
+            .round
+            .as_mut()
+            .unwrap()
+            .pending
+            .pop_front()
+            .expect("advance implies a pending stage");
+        let new_slots = self
+            .launch_eval_stage(owner, project, seq, &branch, cycle, next)
+            .await?;
+        let round = self.active.get_mut(&key).unwrap().round.as_mut().unwrap();
+        let finished = std::mem::replace(&mut round.slots, new_slots);
+        round.done.extend(finished);
         Ok(())
     }
 
@@ -603,7 +725,10 @@ impl Core {
             // (design-lifecycle.md abort verdict). Advisory aborts are plain
             // advisory fails.
             let mut aborted: Vec<String> = Vec::new();
-            for slot in &round.slots {
+            // Every stage that ran: earlier stages that passed (`done`) plus the
+            // final stage (`slots`). Stages that were never created — skipped by
+            // a short-circuit — contribute nothing, exactly as intended.
+            for slot in round.done.iter().chain(round.slots.iter()) {
                 let required = slot.evaluator.required.unwrap_or(true);
                 match slot.outcome.as_ref().expect("complete") {
                     SlotOutcome::Product {
@@ -954,7 +1079,7 @@ impl Core {
                 self.active.get_mut(&key).expect("exec state").gate = Some(GateState {
                     commit,
                     old_head: head,
-                    round: EvalRound { slots },
+                    round: EvalRound::single(slots),
                 });
                 Ok(FinalizeStep::Gating)
             }
@@ -1160,5 +1285,130 @@ impl Core {
         .await?;
         self.enter_work(owner, project, seq, cycle + 1, Vec::new(), Some(context))
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit coverage for the staged-evaluation decision core (spec §3.3): how
+    //! evaluators partition into stages, and whether a completed stage lets the
+    //! next one start. These are the pure fragments of the reduce path; the
+    //! stateful reduce/advance flow is exercised end-to-end in Tier-2
+    //! (`tests/execution.rs`).
+    use super::*;
+    use types::EvaluatorType;
+
+    fn evaluator(name: &str, stage: u32, required: Option<bool>) -> Evaluator {
+        Evaluator {
+            name: name.into(),
+            r#type: EvaluatorType::Command,
+            image: None,
+            run: Some("true".into()),
+            prompt: None,
+            provider: None,
+            model: None,
+            secrets: vec![],
+            required,
+            stage,
+        }
+    }
+
+    fn slot(name: &str, stage: u32, required: Option<bool>, outcome: SlotOutcome) -> EvalSlot {
+        EvalSlot {
+            evaluator: evaluator(name, stage, required),
+            task_id: 0,
+            attempt: 1,
+            outcome: Some(outcome),
+        }
+    }
+
+    fn product(pass: bool, abort: bool) -> SlotOutcome {
+        SlotOutcome::Product {
+            pass,
+            abort,
+            structured: None,
+        }
+    }
+
+    #[test]
+    fn group_stages_single_stage_is_one_group() {
+        // The compatibility story: every evaluator at the default stage 0 →
+        // exactly one stage, in declared order.
+        let evs = vec![
+            evaluator("a", 0, None),
+            evaluator("b", 0, None),
+            evaluator("c", 0, None),
+        ];
+        let stages = group_stages(evs);
+        assert_eq!(stages.len(), 1);
+        let names: Vec<_> = stages[0].iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn group_stages_orders_by_stage_stable_within() {
+        // Out-of-order, multi-stage input sorts ascending; declared order is
+        // preserved within a stage (stable).
+        let evs = vec![
+            evaluator("ci", 1, None),
+            evaluator("review", 0, None),
+            evaluator("lint", 1, None),
+            evaluator("gate", 2, None),
+        ];
+        let stages: Vec<Vec<_>> = group_stages(evs)
+            .into_iter()
+            .map(|s| s.into_iter().map(|e| e.name).collect())
+            .collect();
+        assert_eq!(
+            stages,
+            vec![
+                vec!["review".to_string()],
+                vec!["ci".to_string(), "lint".to_string()],
+                vec!["gate".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn stage_passed_all_required_pass() {
+        let slots = vec![
+            slot("a", 0, None, product(true, false)),
+            slot("b", 0, Some(true), product(true, false)),
+        ];
+        assert!(stage_passed(&slots));
+    }
+
+    #[test]
+    fn stage_passed_required_fail_blocks() {
+        let slots = vec![
+            slot("a", 0, None, product(true, false)),
+            slot("b", 0, None, product(false, false)),
+        ];
+        assert!(!stage_passed(&slots));
+    }
+
+    #[test]
+    fn stage_passed_required_abort_blocks() {
+        let slots = vec![slot("a", 0, None, product(false, true))];
+        assert!(!stage_passed(&slots));
+    }
+
+    #[test]
+    fn stage_passed_required_infra_blocks() {
+        let slots = vec![slot("a", 0, None, SlotOutcome::Infra)];
+        assert!(!stage_passed(&slots));
+    }
+
+    #[test]
+    fn stage_passed_advisory_failures_never_block() {
+        // Advisory fail, advisory abort, advisory infra — none stop the next
+        // stage from starting.
+        let slots = vec![
+            slot("pass", 0, None, product(true, false)),
+            slot("adv-fail", 0, Some(false), product(false, false)),
+            slot("adv-abort", 0, Some(false), product(false, true)),
+            slot("adv-infra", 0, Some(false), SlotOutcome::Infra),
+        ];
+        assert!(stage_passed(&slots));
     }
 }

--- a/crates/dispatcher/src/exec.rs
+++ b/crates/dispatcher/src/exec.rs
@@ -263,6 +263,7 @@ impl Core {
             },
             attempt,
             evaluator: None,
+            stage: 0,
             container_id: None,
             session_id: session_id.clone(),
             result: None,

--- a/crates/dispatcher/src/handlers.rs
+++ b/crates/dispatcher/src/handlers.rs
@@ -1007,6 +1007,7 @@ mod tests {
             state,
             attempt: 1,
             evaluator: None,
+            stage: 0,
             container_id: None,
             session_id: None,
             result: None,

--- a/crates/dispatcher/src/reconcile.rs
+++ b/crates/dispatcher/src/reconcile.rs
@@ -115,7 +115,6 @@ impl Core {
         let cycle = self.active.get(&key).expect("exec state").cycle;
         let all = self.tasks.list_for_job(owner, project, seq).await?;
 
-        // Rebuild the round: one slot per evaluator, latest task per name.
         let evaluators = self
             .active
             .get(&key)
@@ -127,21 +126,66 @@ impl Core {
             // Auto-pass job caught between Evaluation and Done: re-finalize.
             return self.refinalize(owner, project, seq).await;
         }
-        let mut slots = Vec::new();
-        let mut running: Vec<Task> = Vec::new();
-        for evaluator in evaluators {
-            let latest = all
-                .iter()
+
+        // Rebuild the staged round from the task log (§3.3). Stages are launched
+        // in order, so the started stages form a prefix: the last stage with any
+        // task this cycle is the one in flight (`slots`), earlier stages are
+        // `done`, later stages `pending` (no tasks yet). A single-stage job
+        // collapses to one group — identical to the pre-staging rebuild.
+        let stages: Vec<Vec<types::Evaluator>> =
+            crate::eval::group_stages(evaluators).into_iter().collect();
+        let latest = |ev: &types::Evaluator| -> Option<Task> {
+            all.iter()
                 .filter(|t| {
                     t.phase == TaskPhase::Evaluation
                         && t.cycle == cycle
-                        && t.evaluator.as_deref() == Some(evaluator.name.as_str())
+                        && t.evaluator.as_deref() == Some(ev.name.as_str())
                 })
                 .max_by_key(|t| t.id)
-                .cloned();
-            match latest {
+                .cloned()
+        };
+        let current_idx = stages
+            .iter()
+            .rposition(|stage| stage.iter().any(|ev| latest(ev).is_some()))
+            .unwrap_or(0);
+
+        // Earlier stages passed before we advanced: rebuild their terminal
+        // outcomes so the reduce sees the whole run. A non-terminal task here is
+        // structurally impossible; treat one as infra rather than panic.
+        let mut done: Vec<EvalSlot> = Vec::new();
+        for stage in &stages[..current_idx] {
+            for evaluator in stage {
+                let (task_id, attempt, outcome) = match latest(evaluator) {
+                    Some(task) => (
+                        task.id,
+                        task.attempt,
+                        match (task.state, &task.result) {
+                            (TaskState::Done, Some(r)) => SlotOutcome::Product {
+                                pass: result_pass(r),
+                                abort: result_abort(r),
+                                structured: result_structured(r),
+                            },
+                            _ => SlotOutcome::Infra,
+                        },
+                    ),
+                    None => (0, 1, SlotOutcome::Infra),
+                };
+                done.push(EvalSlot {
+                    evaluator: evaluator.clone(),
+                    task_id,
+                    attempt,
+                    outcome: Some(outcome),
+                });
+            }
+        }
+
+        // The stage in flight: rebuild each slot, relaunching any evaluator that
+        // never got a task (crashed mid-fan-out).
+        let mut slots = Vec::new();
+        let mut running: Vec<Task> = Vec::new();
+        for evaluator in stages[current_idx].clone() {
+            match latest(&evaluator) {
                 None => {
-                    // Crashed mid-fan-out: this evaluator never got a task.
                     let branch = self.must_get(owner, project, seq)?.branch.clone();
                     let task_id = self
                         .launch_evaluator_task(
@@ -185,15 +229,22 @@ impl Core {
             }
         }
         let complete = slots.iter().all(|s| s.outcome.is_some());
-        self.active.get_mut(&key).expect("exec state").round = Some(EvalRound { slots });
+        let pending: std::collections::VecDeque<Vec<types::Evaluator>> =
+            stages[current_idx + 1..].to_vec().into();
+        self.active.get_mut(&key).expect("exec state").round = Some(EvalRound {
+            slots,
+            pending,
+            done,
+        });
 
         for task in running {
             self.settle_running(owner, project, seq, task).await?;
         }
         if complete {
-            // No Running tasks and every slot resolved before the crash: the
-            // reduce (and possibly the merge) was lost — replay it.
-            return self.refinalize(owner, project, seq).await;
+            // No Running tasks and every slot in the stage resolved before the
+            // crash: replay the advance-or-reduce decision — it may launch the
+            // next stage or run the (lost) reduce and merge.
+            return self.stage_complete(owner, project, seq).await;
         }
         Ok(())
     }

--- a/crates/dispatcher/src/release.rs
+++ b/crates/dispatcher/src/release.rs
@@ -288,3 +288,73 @@ async fn read(
             )]
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn agent_type_with_memory(mem: &str) -> JobType {
+        JobType::parse(&format!(
+            r#"
+name: code
+image: img:latest
+work:
+  type: agent
+  prompt: p.md
+resources:
+  memory: "{mem}"
+"#
+        ))
+        .unwrap()
+    }
+
+    fn job_with_extra_eval() -> Job {
+        Job {
+            id: 1,
+            project: "acme/api".into(),
+            r#type: "code".into(),
+            title: String::new(),
+            description: String::new(),
+            deps: vec![],
+            state: types::JobState::Ready,
+            branch: "job/1".into(),
+            base_ref: None,
+            knowledge_tags: vec![],
+            eval: vec![Evaluator {
+                name: "extra-ci".into(),
+                r#type: EvaluatorType::Command,
+                image: None,
+                run: Some("./ci.sh".into()),
+                prompt: None,
+                provider: None,
+                model: None,
+                secrets: vec![],
+                required: None,
+            }],
+            timeout: None,
+            factory: None,
+            created_at: Utc::now(),
+            ready_at: None,
+        }
+    }
+
+    /// Release validation reuses `types::JobType::validate`, so a malformed
+    /// `resources.memory` (the dogfood `5g` bug) surfaces as a
+    /// `ValidationError` at release time instead of wedging at container
+    /// launch. Good limits pass clean.
+    #[test]
+    fn release_validation_rejects_bad_memory() {
+        let errs = with_job_evaluators(agent_type_with_memory("5g"), &job_with_extra_eval())
+            .expect_err("5g must fail release validation");
+        assert!(
+            errs.iter().any(|e| e.message.contains("resources.memory")),
+            "expected a resources.memory error, got {errs:?}"
+        );
+
+        assert!(
+            with_job_evaluators(agent_type_with_memory("5Gi"), &job_with_extra_eval()).is_ok(),
+            "5Gi must pass release validation"
+        );
+    }
+}

--- a/crates/dispatcher/src/release.rs
+++ b/crates/dispatcher/src/release.rs
@@ -331,6 +331,7 @@ resources:
                 model: None,
                 secrets: vec![],
                 required: None,
+                stage: 0,
             }],
             timeout: None,
             factory: None,

--- a/crates/dispatcher/src/triage.rs
+++ b/crates/dispatcher/src/triage.rs
@@ -109,6 +109,7 @@ impl Core {
             state: TaskState::Running,
             attempt: 1,
             evaluator: None,
+            stage: 0,
             container_id: None,
             session_id: Some(session_id.clone()),
             result: None,

--- a/crates/dispatcher/tests/execution.rs
+++ b/crates/dispatcher/tests/execution.rs
@@ -46,6 +46,46 @@ work_retries: 1
 knowledge: [rust]
 "#;
 
+// Staged evaluation (spec §3.3): a required stage-0 agent review gates a
+// stage-1 command evaluator. review runs first; ci only after it passes.
+const STAGED: &str = r#"
+name: staged
+image: img:latest
+work:
+  type: agent
+  prompt: prompts/impl.md
+rework_budget: 1
+eval:
+  - name: review
+    type: agent
+    prompt: prompts/eval.md
+    stage: 0
+  - name: ci
+    type: command
+    run: ./ci.sh
+    stage: 1
+"#;
+
+// Same shape but the stage-0 review is advisory: its failure must not stop the
+// stage-1 evaluator from running.
+const STAGED_ADVISORY: &str = r#"
+name: staged-advisory
+image: img:latest
+work:
+  type: agent
+  prompt: prompts/impl.md
+eval:
+  - name: review
+    type: agent
+    prompt: prompts/eval.md
+    required: false
+    stage: 0
+  - name: ci
+    type: command
+    run: ./ci.sh
+    stage: 1
+"#;
+
 struct Rig {
     _server: test_utils::nats::NatsTestServer,
     store: NatsStore,
@@ -71,6 +111,8 @@ async fn rig_with_artifacts(artifacts_identity: Option<String>) -> Option<Rig> {
         ("jobs/impl-cmd.yaml", IMPL_CMD_EVAL),
         ("jobs/impl-agent.yaml", IMPL_AGENT_EVAL),
         ("jobs/flaky.yaml", FLAKY),
+        ("jobs/staged.yaml", STAGED),
+        ("jobs/staged-advisory.yaml", STAGED_ADVISORY),
         ("prompts/impl.md", "implement it"),
         ("prompts/eval.md", "review it"),
         ("tags/rust.md", "# rust\nrust conventions here"),
@@ -744,6 +786,244 @@ async fn eval_abort_escalates_without_consuming_rework_budget() {
     }
 }
 
+/// Staged evaluation happy path (spec §3.3): the stage-0 review runs first and
+/// the stage-1 `ci` command evaluator is created only after it passes. Both
+/// tasks carry their `stage`, and only two agent runs happen (work + review).
+#[tokio::test]
+async fn staged_eval_review_passes_then_ci_runs_and_merges() {
+    let Some(rig) = rig().await else { return };
+    let handle = rig.handle.clone();
+    let bare = rig.repo.bare_path();
+
+    rig.provider.on_run(move |cfg| async move {
+        let branch = cfg.env.get("JOB_BRANCH").unwrap().clone();
+        let clone = clone_branch_from(&bare, &branch).await;
+        clone
+            .commit_file("src/new.rs", b"pub fn f() {}", "implement")
+            .await;
+        clone.push(&branch).await;
+    });
+    let h = handle.clone();
+    rig.provider.on_run(move |_| async move {
+        // Stage-0 review verdict (task 2).
+        h.submit_eval(
+            "acme",
+            "api",
+            1,
+            2,
+            EvalSubmission {
+                pass: true,
+                abort: false,
+                structured: None,
+                token_usage: None,
+            },
+        )
+        .await
+        .unwrap();
+    });
+
+    let job = rig.handle.create_job(req("staged")).await.unwrap();
+    rig.handle.release_job("acme", "api", job.id).await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Done).await;
+
+    let tasks = rig
+        .store
+        .tasks()
+        .await
+        .unwrap()
+        .list_for_job("acme", "api", job.id)
+        .await
+        .unwrap();
+    // work(1), review(2, stage 0), ci(3, stage 1) — nothing else.
+    assert_eq!(tasks.len(), 3);
+    assert_eq!(tasks[1].evaluator.as_deref(), Some("review"));
+    assert_eq!(tasks[1].stage, 0);
+    assert_eq!(tasks[2].evaluator.as_deref(), Some("ci"));
+    assert_eq!(tasks[2].stage, 1);
+    // The gate is ordered: ci is created only after review completes.
+    assert!(tasks[2].created_at >= tasks[1].completed_at.unwrap());
+    assert_eq!(
+        rig.provider.runs().len(),
+        2,
+        "only work + review run agents"
+    );
+}
+
+/// Required stage-0 failure short-circuits: the stage-1 `ci` task is never
+/// created for that cycle, and the rework cycle restarts from stage 0 (review
+/// again). Directly the acceptance case — a review-rejected change spends no CI.
+#[tokio::test]
+async fn staged_eval_required_review_fail_skips_ci_and_reworks_from_stage0() {
+    let Some(rig) = rig().await else { return };
+    let handle = rig.handle.clone();
+
+    rig.provider.on_run(|_| async {}); // work cycle 1
+    let h = handle.clone();
+    rig.provider.on_run(move |_| async move {
+        // Stage-0 review fails (task 2) → short-circuit; no ci this cycle.
+        h.submit_eval(
+            "acme",
+            "api",
+            1,
+            2,
+            EvalSubmission {
+                pass: false,
+                abort: false,
+                structured: Some(serde_json::json!({"issues": ["needs tests"]})),
+                token_usage: None,
+            },
+        )
+        .await
+        .unwrap();
+    });
+    rig.provider.on_run(|_| async {}); // work cycle 2
+    let h = handle.clone();
+    rig.provider.on_run(move |_| async move {
+        // Rework restarts at stage 0: review again (task 4), now passing.
+        h.submit_eval(
+            "acme",
+            "api",
+            1,
+            4,
+            EvalSubmission {
+                pass: true,
+                abort: false,
+                structured: None,
+                token_usage: None,
+            },
+        )
+        .await
+        .unwrap();
+    });
+
+    let job = rig.handle.create_job(req("staged")).await.unwrap();
+    rig.handle.release_job("acme", "api", job.id).await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Done).await;
+
+    let tasks = rig
+        .store
+        .tasks()
+        .await
+        .unwrap()
+        .list_for_job("acme", "api", job.id)
+        .await
+        .unwrap();
+    let ci = |cycle: u32| {
+        tasks.iter().any(|t| {
+            t.phase == TaskPhase::Evaluation
+                && t.cycle == cycle
+                && t.evaluator.as_deref() == Some("ci")
+        })
+    };
+    // Cycle 1's failed review created no ci task; cycle 2's passing review did.
+    assert!(!ci(1), "stage-1 ci must not run when stage-0 review fails");
+    assert!(ci(2), "ci runs once review passes on the rework cycle");
+    // The rework cycle re-opened at stage 0 with a fresh review task.
+    assert!(tasks.iter().any(|t| {
+        t.phase == TaskPhase::Evaluation
+            && t.cycle == 2
+            && t.evaluator.as_deref() == Some("review")
+            && t.stage == 0
+    }));
+}
+
+/// Advisory stage-0 failure does not block: a `required: false` review that
+/// fails still lets the stage-1 `ci` evaluator run, and the required ci pass
+/// carries the job to Done.
+#[tokio::test]
+async fn staged_eval_advisory_review_fail_still_runs_ci() {
+    let Some(rig) = rig().await else { return };
+    let handle = rig.handle.clone();
+
+    rig.provider.on_run(|_| async {}); // work
+    let h = handle.clone();
+    rig.provider.on_run(move |_| async move {
+        h.submit_eval(
+            "acme",
+            "api",
+            1,
+            2,
+            EvalSubmission {
+                pass: false, // advisory fail
+                abort: false,
+                structured: None,
+                token_usage: None,
+            },
+        )
+        .await
+        .unwrap();
+    });
+
+    let job = rig.handle.create_job(req("staged-advisory")).await.unwrap();
+    rig.handle.release_job("acme", "api", job.id).await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Done).await;
+
+    let tasks = rig
+        .store
+        .tasks()
+        .await
+        .unwrap()
+        .list_for_job("acme", "api", job.id)
+        .await
+        .unwrap();
+    // work(1), advisory review(2, failed), ci(3, passed) → merged.
+    assert_eq!(tasks.len(), 3);
+    assert!(matches!(
+        tasks[1].result,
+        Some(types::TaskResult::Agent { pass: false, .. })
+    ));
+    assert_eq!(tasks[2].evaluator.as_deref(), Some("ci"));
+    assert_eq!(tasks[2].state, TaskState::Done);
+}
+
+/// An abort from a required stage-0 evaluator escalates immediately: no later
+/// stage is created, and (like any abort) the rework budget is not consumed.
+#[tokio::test]
+async fn staged_eval_stage0_abort_escalates_without_ci() {
+    let Some(rig) = rig().await else { return };
+    let handle = rig.handle.clone();
+
+    rig.provider.on_run(|_| async {}); // work
+    let h = handle.clone();
+    rig.provider.on_run(move |_| async move {
+        h.submit_eval(
+            "acme",
+            "api",
+            1,
+            2,
+            EvalSubmission {
+                pass: false,
+                abort: true,
+                structured: Some(serde_json::json!({"reason": "wrong premise"})),
+                token_usage: None,
+            },
+        )
+        .await
+        .unwrap();
+    });
+
+    let job = rig.handle.create_job(req("staged")).await.unwrap();
+    rig.handle.release_job("acme", "api", job.id).await.unwrap();
+    wait_for_state(&rig.store, job.id, JobState::Escalated).await;
+
+    assert_eq!(rig.provider.runs().len(), 2, "no rework after abort");
+    let tasks = rig
+        .store
+        .tasks()
+        .await
+        .unwrap()
+        .list_for_job("acme", "api", job.id)
+        .await
+        .unwrap();
+    // work(1), review abort(2), Human escalation(3) — no ci ever.
+    assert_eq!(tasks.len(), 3);
+    assert!(
+        !tasks.iter().any(|t| t.evaluator.as_deref() == Some("ci")),
+        "the stage-1 ci evaluator must never be created after a stage-0 abort"
+    );
+    assert!(matches!(tasks[2].kind, types::TaskKind::Human { .. }));
+}
+
 /// Additive per-job evaluators: layered on top of the type's list and executed
 /// like declared ones.
 #[tokio::test]
@@ -761,6 +1041,7 @@ async fn job_level_evaluators_run_alongside_type_evaluators() {
         model: None,
         secrets: vec![],
         required: None,
+        stage: 0,
     }];
     let job = rig.handle.create_job(r).await.unwrap();
     rig.handle.release_job("acme", "api", job.id).await.unwrap();
@@ -826,6 +1107,7 @@ async fn job_evaluator_name_collision_fails_release() {
         model: None,
         secrets: vec![],
         required: None,
+        stage: 0,
     }];
     let job = rig.handle.create_job(r).await.unwrap(); // creation always lands Frozen
     let err = rig

--- a/crates/dispatcher/tests/recovery.rs
+++ b/crates/dispatcher/tests/recovery.rs
@@ -188,6 +188,7 @@ async fn restart_recovers_orphaned_running_work_task() {
             state: TaskState::Running,
             attempt: 1,
             evaluator: None,
+            stage: 0,
             container_id: None,
             session_id: None, // gone with the crashed dispatcher
             result: None,
@@ -302,6 +303,7 @@ async fn restart_lands_job_orphaned_in_wrapup() {
             state: TaskState::Done,
             attempt: 1,
             evaluator: None,
+            stage: 0,
             container_id: None,
             session_id: None,
             result: Some(types::TaskResult::Work {
@@ -564,6 +566,7 @@ async fn restart_preserves_the_submitted_summary_for_the_squash_commit() {
             state: TaskState::Done,
             attempt: 1,
             evaluator: None,
+            stage: 0,
             container_id: None,
             session_id: Some("da08d5f3-844e-430e-8363-39b4882f437b".into()),
             result: Some(types::TaskResult::Work {

--- a/crates/store/tests/nats_store.rs
+++ b/crates/store/tests/nats_store.rs
@@ -43,6 +43,7 @@ fn task(job_seq: u64, id: u64) -> Task {
         state: TaskState::Pending,
         attempt: 1,
         evaluator: None,
+        stage: 0,
         container_id: None,
         session_id: None,
         result: None,

--- a/crates/types/src/job_type.rs
+++ b/crates/types/src/job_type.rs
@@ -159,6 +159,13 @@ pub struct Evaluator {
     pub secrets: Vec<String>,
     /// Default true; false = advisory.
     pub required: Option<bool>,
+    /// Staged evaluation ordering (spec §3.3): evaluators run in ascending
+    /// `stage` order; within a stage they fan out in parallel. A later stage's
+    /// tasks are created only after every *required* evaluator in the prior
+    /// stage passes. Default 0 — a single-stage job is byte-for-byte the
+    /// unstaged behavior. Non-negative (`u32`, enforced at parse).
+    #[serde(default)]
+    pub stage: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -687,6 +694,87 @@ wrap_up:
         let jt = JobType::parse(yaml).unwrap();
         assert_eq!(jt.wrap_up.r#type, WrapUpMode::None);
         assert_eq!(jt.validate(), vec![]);
+    }
+
+    #[test]
+    fn evaluator_stage_defaults_zero_parses_and_validates() {
+        // Omitted `stage` defaults to 0 across all evaluator kinds; an explicit
+        // non-negative value parses. A negative value is rejected at parse
+        // (serde into u32), so it can never reach validate().
+        let jt = JobType::parse(SPEC_EXAMPLE).unwrap();
+        assert!(jt.eval.iter().all(|e| e.stage == 0));
+
+        let yaml = r#"
+name: impl
+image: img:latest
+work:
+  type: agent
+  prompt: p.md
+eval:
+  - name: review
+    type: agent
+    prompt: r.md
+    stage: 0
+  - name: ci
+    type: command
+    run: ./ci.sh
+    stage: 2
+"#;
+        let jt = JobType::parse(yaml).unwrap();
+        assert_eq!(jt.eval[0].stage, 0);
+        assert_eq!(jt.eval[1].stage, 2);
+        assert_eq!(jt.validate(), vec![]);
+
+        let negative = r#"
+name: impl
+image: img:latest
+work:
+  type: agent
+  prompt: p.md
+eval:
+  - name: review
+    type: agent
+    prompt: r.md
+    stage: -1
+"#;
+        assert!(JobType::parse(negative).is_err());
+    }
+
+    #[test]
+    fn project_defaults_preserve_declared_stage_after_append() {
+        // The append does not reorder; the default keeps whatever `stage` it
+        // declares, so a job type's stage-0 review sits ahead of a stage-1 CI
+        // default in the merged list.
+        let yaml = r#"
+name: code
+image: img:latest
+work:
+  type: agent
+  prompt: p.md
+eval:
+  - name: review
+    type: agent
+    prompt: r.md
+    stage: 0
+"#;
+        let jt = JobType::parse(yaml).unwrap();
+        let defaults = ProjectDefaults::parse(
+            r#"
+eval:
+  - name: ci
+    type: command
+    run: ./tasks/ci.sh
+    stage: 1
+"#,
+        )
+        .unwrap();
+        let merged = jt.with_defaults(&defaults).unwrap();
+        assert_eq!(merged.eval.len(), 2);
+        assert_eq!(merged.eval[0].name, "review");
+        assert_eq!(merged.eval[0].stage, 0);
+        assert_eq!(merged.eval[1].name, "ci");
+        assert_eq!(merged.eval[1].stage, 1);
+        assert_eq!(merged.validate(), vec![]);
     }
 
     #[test]

--- a/crates/types/src/job_type.rs
+++ b/crates/types/src/job_type.rs
@@ -134,6 +134,11 @@ pub enum Provider {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Resources {
     pub cpu: Option<f64>,
+    /// Memory limit: a positive integer, optionally suffixed with a binary
+    /// unit (`Ki`/`Mi`/`Gi`), or plain bytes — e.g. `512Mi`, `4Gi`, `1048576`.
+    /// No other suffixes (`5g`, `4GB` are rejected). Validated at parse time so
+    /// a bad value fails offline instead of at container launch.
+    #[cfg_attr(feature = "schema", schemars(extend("pattern" = crate::resources::MEMORY_PATTERN)))]
     pub memory: Option<String>,
     pub task_timeout: Option<String>,
 }
@@ -363,6 +368,22 @@ impl JobType {
             }
         }
 
+        // `resources.memory` is an opaque string until the container backend
+        // parses it at launch; validate the format here so `chuggernaut
+        // validate` and release validation reject a bad limit (e.g. "5g")
+        // offline instead of wedging the job when the eval container fails to
+        // launch. `resources.cpu` needs no such check — serde already enforces
+        // it is a float, and it is never re-parsed from a string downstream.
+        if let Some(mem) = self.resources.as_ref().and_then(|r| r.memory.as_deref())
+            && let Err(e) = crate::resources::parse_memory(mem)
+        {
+            errs.push(FieldRuleError::Invalid {
+                field: "resources.memory",
+                context: format!("job type '{}'", self.name),
+                reason: e.to_string(),
+            });
+        }
+
         let durations = [
             (
                 self.resources
@@ -551,6 +572,53 @@ job_deadline: 24h
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn memory_format_validated() {
+        let jt_with_mem = |mem: &str| {
+            JobType::parse(&format!(
+                r#"
+name: impl
+image: img:latest
+work:
+  type: agent
+  prompt: p.md
+resources:
+  memory: "{mem}"
+"#
+            ))
+            .unwrap()
+        };
+
+        // The dogfood bug: "5g" passed validate but failed at launch.
+        let errs = jt_with_mem("5g").validate();
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(
+            &errs[0],
+            FieldRuleError::Invalid {
+                field: "resources.memory",
+                ..
+            }
+        ));
+        // The accepted form validates cleanly.
+        assert_eq!(jt_with_mem("5Gi").validate(), vec![]);
+        assert_eq!(jt_with_mem("512Mi").validate(), vec![]);
+        assert_eq!(jt_with_mem("1048576").validate(), vec![]);
+
+        // Other malformed forms are all rejected offline.
+        for bad in ["4GB", "-5", "0", "1.5Gi"] {
+            assert!(
+                jt_with_mem(bad).validate().iter().any(|e| matches!(
+                    e,
+                    FieldRuleError::Invalid {
+                        field: "resources.memory",
+                        ..
+                    }
+                )),
+                "should reject memory: {bad}"
+            );
+        }
     }
 
     #[test]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod job_type;
 pub mod knowledge;
 pub mod platform;
 pub mod project;
+pub mod resources;
 pub mod step;
 pub mod task;
 pub mod user;
@@ -25,6 +26,7 @@ pub use job_type::{
 pub use knowledge::{KnowledgeObject, KnowledgeScope};
 pub use platform::{DispatcherConfigSnapshot, WorkerNode};
 pub use project::{OriginLink, ProjectRecord, ReleaseState, ReleaseStatus, github_repo_from_url};
+pub use resources::{MEMORY_PATTERN, MemoryParseError, parse_memory};
 pub use step::{StepKind, StepRecord, StepStatus};
 pub use task::{
     EscalationAction, EvalResult, Task, TaskKind, TaskPhase, TaskResolution, TaskResult, TaskState,

--- a/crates/types/src/resources.rs
+++ b/crates/types/src/resources.rs
@@ -1,0 +1,88 @@
+//! Resource-limit string parsing (spec §1.1: `resources.memory`).
+//!
+//! Format: a positive integer, optionally suffixed with a binary unit
+//! (`Ki`/`Mi`/`Gi`), or plain bytes ("512Mi", "4Gi", "1048576"). This is the
+//! single shared grammar: the YAML layer keeps the limit as a string, and both
+//! `types` field-rules validation and the container backend's launch-time parse
+//! go through here — so a malformed limit is rejected offline at `validate`
+//! time instead of wedging a job when the container fails to launch.
+
+use thiserror::Error;
+
+/// The regex describing an accepted memory-limit string. Kept alongside the
+/// parser so the JSON Schema (`chuggernaut schema job-type`) documents exactly
+/// what [`parse_memory`] accepts.
+pub const MEMORY_PATTERN: &str = r"^[0-9]+(Ki|Mi|Gi)?$";
+
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum MemoryParseError {
+    #[error("empty memory limit")]
+    Empty,
+    #[error(
+        "invalid memory limit {input:?}: {reason} \
+         (expected a positive integer optionally suffixed with Ki/Mi/Gi, \
+         e.g. 512Mi, 4Gi, or plain bytes)"
+    )]
+    Invalid { input: String, reason: String },
+}
+
+/// Parse a memory-limit string like "512Mi", "4Gi", or plain bytes ("1048576")
+/// into a byte count. Rejects unknown suffixes (e.g. "5g", "4GB"), non-integer,
+/// zero, and negative values — matching what the container backend accepts at
+/// launch.
+pub fn parse_memory(input: &str) -> Result<i64, MemoryParseError> {
+    let s = input.trim();
+    if s.is_empty() {
+        return Err(MemoryParseError::Empty);
+    }
+    let invalid = |reason: &str| MemoryParseError::Invalid {
+        input: input.to_string(),
+        reason: reason.to_string(),
+    };
+
+    let (num, mult) = if let Some(n) = s.strip_suffix("Ki") {
+        (n, 1024i64)
+    } else if let Some(n) = s.strip_suffix("Mi") {
+        (n, 1024 * 1024)
+    } else if let Some(n) = s.strip_suffix("Gi") {
+        (n, 1024 * 1024 * 1024)
+    } else {
+        (s, 1)
+    };
+    // Only a bare non-negative integer is a legal numeric part; this rejects
+    // signs, decimals, and stray unit letters (the "g" in "5g", "GB" in "4GB").
+    if num.is_empty() || !num.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(invalid("expected a positive integer"));
+    }
+    let value: i64 = num.parse().map_err(|_| invalid("number out of range"))?;
+    let bytes = value
+        .checked_mul(mult)
+        .ok_or_else(|| invalid("memory limit overflows"))?;
+    if bytes <= 0 {
+        return Err(invalid("memory limit must be positive"));
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_spec_forms() {
+        assert_eq!(parse_memory("5Gi").unwrap(), 5 * 1024 * 1024 * 1024);
+        assert_eq!(parse_memory("512Mi").unwrap(), 512 * 1024 * 1024);
+        assert_eq!(parse_memory("4Ki").unwrap(), 4 * 1024);
+        assert_eq!(parse_memory("1048576").unwrap(), 1_048_576);
+    }
+
+    #[test]
+    fn rejects_malformed() {
+        // The exact cases from the dogfood bug and the acceptance criteria.
+        for bad in [
+            "5g", "4GB", "", "  ", "-5", "-5Gi", "0", "1.5Gi", "Gi", "5 Gi", "5gi",
+        ] {
+            assert!(parse_memory(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+}

--- a/crates/types/src/task.rs
+++ b/crates/types/src/task.rs
@@ -22,6 +22,12 @@ pub struct Task {
     /// reconciliation and the UI both need the mapping.
     #[serde(default)]
     pub evaluator: Option<String>,
+    /// Evaluation stage this task belongs to (spec §3.3 staged evaluation).
+    /// Carries the evaluator's `stage:` for Evaluation/MergeGate tasks so the
+    /// UI can group a cycle's tasks by stage; 0 for work/escalation/triage
+    /// tasks, which have no stage. Defaulted for records written before staging.
+    #[serde(default)]
+    pub stage: u32,
     /// Backend-assigned container ID (Docker or k8s); None for Human tasks.
     pub container_id: Option<String>,
     /// Agent tasks only: the session id handed to the agent CLI, which names

--- a/jobs/_defaults.yaml
+++ b/jobs/_defaults.yaml
@@ -1,6 +1,12 @@
 # Appended to every job type's eval list (spec §1.1) — the evergreen CI gate.
+# stage: 1 places CI after any stage-0 evaluators (spec §3.3 staged evaluation):
+# for the `code` type, the authoritative review runs first and CI — a slow cold
+# cargo build on the shared Docker host — runs only once review passes. Types
+# with no stage-0 evaluators of their own run CI as their sole (stage-1) stage,
+# unchanged from before.
 eval:
   - name: ci
     type: command
     image: chuggernaut/agent-rust:prod
     run: ./tasks/ci.sh
+    stage: 1

--- a/jobs/code.yaml
+++ b/jobs/code.yaml
@@ -12,6 +12,16 @@ work:
   review:
     prompt: prompts/review/code.md
     iterations: 3
+# Staged evaluation (spec §3.3): an authoritative agentic review gates the CI
+# command evaluator. CI on this project is a cold cargo build — slow, and it
+# loads the shared Docker host — so there is no point spending it on a change
+# the reviewer will reject. Review runs in stage 0; the appended `ci` default
+# (jobs/_defaults.yaml) is stage 1 and only runs if review passes.
+eval:
+  - name: review
+    type: agent
+    prompt: tasks/review-code.md
+    stage: 0
 resources:
   cpu: 3
   memory: 5Gi

--- a/schemas/defaults.schema.json
+++ b/schemas/defaults.schema.json
@@ -69,6 +69,13 @@
             "type": "string"
           }
         },
+        "stage": {
+          "description": "Staged evaluation ordering (spec §3.3): evaluators run in ascending\n`stage` order; within a stage they fan out in parallel. A later stage's\ntasks are created only after every *required* evaluator in the prior\nstage passes. Default 0 — a single-stage job is byte-for-byte the\nunstaged behavior. Non-negative (`u32`, enforced at parse).",
+          "type": "integer",
+          "format": "uint32",
+          "default": 0,
+          "minimum": 0
+        },
         "type": {
           "$ref": "#/$defs/EvaluatorType"
         }

--- a/schemas/job-type.schema.json
+++ b/schemas/job-type.schema.json
@@ -160,6 +160,13 @@
             "type": "string"
           }
         },
+        "stage": {
+          "description": "Staged evaluation ordering (spec §3.3): evaluators run in ascending\n`stage` order; within a stage they fan out in parallel. A later stage's\ntasks are created only after every *required* evaluator in the prior\nstage passes. Default 0 — a single-stage job is byte-for-byte the\nunstaged behavior. Non-negative (`u32`, enforced at parse).",
+          "type": "integer",
+          "format": "uint32",
+          "default": 0,
+          "minimum": 0
+        },
         "type": {
           "$ref": "#/$defs/EvaluatorType"
         }

--- a/schemas/job-type.schema.json
+++ b/schemas/job-type.schema.json
@@ -196,10 +196,12 @@
           "format": "double"
         },
         "memory": {
+          "description": "Memory limit: a positive integer, optionally suffixed with a binary\nunit (`Ki`/`Mi`/`Gi`), or plain bytes — e.g. `512Mi`, `4Gi`, `1048576`.\nNo other suffixes (`5g`, `4GB` are rejected). Validated at parse time so\na bad value fails offline instead of at container launch.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "pattern": "^[0-9]+(Ki|Mi|Gi)?$"
         },
         "task_timeout": {
           "type": [

--- a/spec.md
+++ b/spec.md
@@ -99,7 +99,7 @@ work:                          # required
 
 resources:                     # optional; disallowed for work.type: human
   cpu: number
-  memory: string               # e.g. "4Gi"
+  memory: string               # positive integer, optionally suffixed with a binary unit (Ki|Mi|Gi), or plain bytes: "512Mi", "4Gi", "1048576". No other suffixes ("5g", "4GB" are rejected). Format validated at parse time (release + `chuggernaut validate`), not deferred to container launch
   task_timeout: duration       # per-container execution limit; default 1h
 
 wrap_up:                       # optional; the job's third step (work → evaluation → wrap-up); see design-lifecycle.md

--- a/spec.md
+++ b/spec.md
@@ -130,6 +130,7 @@ eval:                          # optional; omit or leave empty for auto-pass
     model: string
 
     required: bool             # optional; default true; false = advisory
+    stage: int                 # optional; default 0; staged-evaluation ordering (§3.3). Non-negative. Evaluators run in ascending stage order; within a stage they fan out in parallel. A later stage's tasks are created only after every required evaluator in the prior stage passes
 
 knowledge: [string]            # default knowledge tags for KO injection at launch
 vars: [string]                 # injected into work container and all eval containers
@@ -166,6 +167,7 @@ vars: [string]                 # injected into work container and all eval conta
 | `model` | disallowed | optional | disallowed |
 | `secrets` | optional | optional | disallowed |
 | `required` | optional | optional | optional |
+| `stage` | optional | optional | optional |
 
 ² Falls back to the job's top-level `image`. Required per-evaluator when the job declares no top-level image (`work.type: human`).
 
@@ -386,7 +388,7 @@ pub enum TaskResolution {
 | Human work task: operator resolves `Fail` | Human escalation task → job → Escalated |
 | Operator grants `Retry` on escalation | New work task (same cycle, attempt++); `work_retries` budget NOT reset |
 | Eval reduce passes, squash-merge conflict | Update `base_ref` to current default HEAD; cycle++ (rework_budget NOT consumed); re-enter Work with conflict context injected |
-| Job enters Evaluation | One task (attempt=1) per evaluator declared in job type |
+| Job enters Evaluation | One task (attempt=1) per evaluator in the lowest `stage` (§3.3); later stages' tasks are created only as each prior stage passes |
 | Agent eval task: container exits with no prior `submit_eval`, `eval_retries` available | Infra error; new task record (same cycle, attempt++) |
 | Agent eval task: `eval_retries` exhausted | Final task marked Failed (infra error); reduce proceeds |
 | Eval reduce fails (`work.type: agent \| human`), under rework budget | Job re-enters Work (cycle++); all eval results feed into next work task |
@@ -581,7 +583,8 @@ The authoritative definition of all valid job state transitions. No transition e
 | `Work` | `Escalated` | Work task fails, no retries left | `attempt > work_retries` | Create Human escalation task; publish `job-escalated` |
 | `Work` | `Escalated` | Human work task resolved `Fail` | — | Create Human escalation task; publish `job-escalated` |
 | `Work` | `Escalated` | Launch-time validation fails (declared secret or var missing from KV) | — | Create Human escalation task; publish `job-escalated` |
-| `Work` | `Evaluation` | Work task succeeds | — | Create one task per declared evaluator (attempt=1); publish `job-evaluation-started` |
+| `Work` | `Evaluation` | Work task succeeds | — | Create one task per evaluator in the lowest `stage` (§3.3 staged evaluation; attempt=1); publish `job-evaluation-started` |
+| `Evaluation` | `Evaluation` | A stage completes with every required evaluator passing and a later stage remains | — | Create the next stage's evaluator tasks (attempt=1); a short-circuited stage creates none |
 | `Evaluation` | `Evaluation` | Agent eval container exits without `submit_eval`, retries remain | `attempt ≤ eval_retries` | Create new eval task (same cycle, attempt++) |
 | `Evaluation` | `Escalated` | Any required eval task exhausts `eval_retries` (infra error) | — | Create Human escalation task; publish `job-escalated` |
 | `Evaluation` | `Work` | Eval reduce: product failure, under rework budget | evaluated cycle N ≤ `rework_budget` | cycle++; collect eval findings into rework context; reset `job/{seq}` to `base_ref`; publish `job-rework-started` (reason: `eval_failure`) |
@@ -771,7 +774,9 @@ For each Ready job, the dispatcher executes the following sequence:
 
 ### 3.3 Evaluation
 
-After a work task succeeds, the dispatcher creates one task per evaluator and fans them out in parallel. For task creation rules see §1.2. For MCP tool contracts see §4.2.
+After a work task succeeds, the dispatcher runs the job's evaluators as an ascending sequence of **stages** (evaluator `stage:`, default 0). When a job enters Evaluation, the dispatcher creates one task per evaluator **in the lowest stage** and fans them out in parallel. Within a stage the evaluators run concurrently exactly as an unstaged fan-out does — a job whose evaluators all share one stage (the default) is byte-for-byte the single-fan-out behavior, and that is the compatibility story. For task creation rules see §1.2. For MCP tool contracts see §4.2.
+
+**Staged progression.** A stage completes when all its tasks reach a terminal state (Done or Failed). If every **required** evaluator in the stage passed, the dispatcher creates the next stage's tasks (one per evaluator, fanned out). If any required evaluator failed or aborted, the later stages are **not created** — they are skipped, not failed, so no task records exist for them — and the eval reduce proceeds immediately over the stages that ran. Advisory (`required: false`) failures never block stage progression. Rework/escalation semantics, abort handling, agent-evaluator retries (`eval_retries`), and human-evaluator pending states are all unchanged **within** a stage; the ordering only governs whether the next stage's tasks are created. A rework cycle re-enters Work and, on the next Evaluation, **restarts from the lowest stage** — stages are recomputed per cycle, never resumed mid-sequence. The per-job additive `eval` entries (§1.1) default to stage 0 unless the creator declares otherwise; the `_defaults.yaml` append (§1.1 Project Default Evaluators) keeps whatever `stage` each default declares and never reorders the list.
 
 **Three evaluator types:**
 
@@ -781,7 +786,7 @@ After a work task succeeds, the dispatcher creates one task per evaluator and fa
 
 **`human`** — dispatcher creates a Human task in `Pending` state. No process launched. Operator submits a `TaskResolution` via the task inbox; the dispatcher writes `TaskResult::Human` to `tasks.*` KV and drives the next state transition.
 
-**Reduce** — applied once all eval tasks are Done or Failed:
+**Reduce** — applied once the evaluation completes: either the final stage's tasks are all Done or Failed, or a stage short-circuited (a required evaluator failed/aborted, so no later stage was created). The reduce considers every evaluator that ran across all stages; skipped stages contribute nothing.
 
 - If any `required` task is Failed (infra error) → skip rework, escalate immediately
 - If a `required: false` task is Failed (infra error) → failure recorded; reduce proceeds; does not trigger escalation (same treatment as a product `pass=false` from an advisory evaluator)
@@ -815,7 +820,7 @@ Applied after the eval reduce passes, before squash-merge — the job is in the 
 
 1. **Skip fast-path** — if the default branch HEAD still equals `base_ref`, or `job/{seq}` has no commits beyond `base_ref`, the evaluators already ran against exactly what will land. Skip the gate; squash-merge directly. Solo jobs pay nothing.
 2. **Candidate construction** — if HEAD moved: build the candidate squash commit (the job branch's changes squashed onto current default HEAD) via `git merge-tree --write-tree` + `git commit-tree`, and point a temp ref `merge-gate/{seq}` at it. If the merge conflicts, this is the existing squash-merge-conflict path (§3.2 step 12) — the gate never runs.
-3. **Gate tasks** — create one `MergeGate` task (attempt=1, current cycle) per **required command evaluator** (job type's own plus project defaults). Each runs exactly like a command eval container (§3.3 `command` semantics: bootstrap clone, exit code is the verdict, `eval-result.json` extraction, no retries) except `JOB_BRANCH=merge-gate/{seq}`. Agent and human evaluators do not re-run — their verdict is about the change; command evaluators verify the integration.
+3. **Gate tasks** — create one `MergeGate` task (attempt=1, current cycle) per **required command evaluator** (job type's own plus project defaults). Each runs exactly like a command eval container (§3.3 `command` semantics: bootstrap clone, exit code is the verdict, `eval-result.json` extraction, no retries) except `JOB_BRANCH=merge-gate/{seq}`. Agent and human evaluators do not re-run — their verdict is about the change; command evaluators verify the integration. The gate **ignores `stage`**: it re-runs the required command evaluators as a single flat fan-out regardless of which stages they were declared in — staging orders only the Evaluation-phase gate on the job branch, not the integration re-check.
 4. **Reduce** — all gate tasks pass → advance the default branch to the candidate commit (this *is* the squash-merge; do not re-merge), delete `job/{seq}` and `merge-gate/{seq}`, transition to Done. Any gate task fails → delete `merge-gate/{seq}`; update `base_ref` to current default HEAD; cycle++ (**rework_budget NOT consumed** — an integration failure is not the author's product failure; same treatment as a merge conflict); reset `job/{seq}` to new `base_ref`; inject the failing command output as `EvalResult` findings plus the conflict-style context block (§4.3: commits and diffstat of what landed since the old base); publish `job-rework-started` (reason: `merge_gate_failure`); re-enter Work.
 
 **Serialization** — the gate is a merge queue of depth 1: at most one job per project is in the gate at a time. Jobs whose eval reduce passes while the gate is occupied queue FIFO; each dequeued job re-checks the skip fast-path against the then-current HEAD. Since the dispatcher already merges sequentially, this adds no new coordination — just a queue in dispatcher memory.


### PR DESCRIPTION
Release 2 from the chuggernaut platform (kasofsk/chuggernaut linked-origin project).

Squash subjects since release 1:
- job/4: code
- job/5: code

**Merge with a merge commit** (not squash) so `integration` fast-forwards on sync. Contains the staged-evaluation dispatcher feature (job #4) whose config half is already live on integration — code-type jobs cannot release until this deploys, so merge when ready.

(PR opened manually again: the dispatcher's PR-create 422s because CHUG_ORIGIN_PAT lacks Contents:Read — fix identified, PAT being updated; retry+error-fidelity is dogfood job #9.)