### PR TITLE
fix(prod): nuc tunnel — detect dead link in ~20s, not ~90s

### DIFF
--- a/deploy/prod/launchd/com.chuggernaut.nuc-tunnel.plist.template
+++ b/deploy/prod/launchd/com.chuggernaut.nuc-tunnel.plist.template
@@ -16,8 +16,9 @@
     <string>-o</string><string>IdentitiesOnly=yes</string>
     <string>-o</string><string>BatchMode=yes</string>
     <string>-o</string><string>ExitOnForwardFailure=yes</string>
-    <string>-o</string><string>ServerAliveInterval=30</string>
-    <string>-o</string><string>ServerAliveCountMax=3</string>
+    <string>-o</string><string>ServerAliveInterval=10</string>
+    <string>-o</string><string>ServerAliveCountMax=2</string>
+    <string>-o</string><string>TCPKeepAlive=yes</string>
     <string>-o</string><string>StrictHostKeyChecking=accept-new</string>
     <string>-L</string><string>127.0.0.1:23751:/run/docker.sock</string>
     <string>worksalot@gumbo-nuc-0</string>


### PR DESCRIPTION
The tunnel dropped twice today on tailscale path renegotiations; each outage lasted the full 90s detection window (30s×3), long enough that job #10's review evaluator burned both eval attempts on 'node nuc: Connect' launch errors and escalated. Tighter keepalives (10s×2 + TCPKeepAlive) bound a drop to ~30s including the restart throttle. Real fix = out-of-service node marking, dogfood job #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)