### PR TITLE
fix(prod): nuc tunnel keepalives must tolerate load stalls (15s x 8)

### DIFF
--- a/deploy/prod/launchd/com.chuggernaut.nuc-tunnel.plist.template
+++ b/deploy/prod/launchd/com.chuggernaut.nuc-tunnel.plist.template
@@ -16,8 +16,8 @@
     <string>-o</string><string>IdentitiesOnly=yes</string>
     <string>-o</string><string>BatchMode=yes</string>
     <string>-o</string><string>ExitOnForwardFailure=yes</string>
-    <string>-o</string><string>ServerAliveInterval=10</string>
-    <string>-o</string><string>ServerAliveCountMax=2</string>
+    <string>-o</string><string>ServerAliveInterval=15</string>
+    <string>-o</string><string>ServerAliveCountMax=8</string>
     <string>-o</string><string>TCPKeepAlive=yes</string>
     <string>-o</string><string>StrictHostKeyChecking=accept-new</string>
     <string>-L</string><string>127.0.0.1:23751:/run/docker.sock</string>


### PR DESCRIPTION
Root cause of today's tunnel 'flaps': they weren't network blips — the tunnel was killing itself under its own transfer load. Big docker operations (build context, 21MB channel-binary put-archive) stall keepalive responses; #42's 10s×2 tuning turned any 20s stall into tunnel suicide at exactly the moment the dispatcher was mid-launch. The nuc's sshd log shows a fresh tunnel session seconds after each failure burst (16:42/16:46/16:54Z), each coinciding with a launch. 15s×8 tolerates ~2min of congestion; true death still detected and restarted by launchd. Already applied live. Also surfaced: eval retries burn 134ms apart against a dead node — no backoff; folded into the #12 discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)