### PR TITLE
fix(worker): implement remove + list_managed_exited on FleetBackend

### DIFF
--- a/crates/container/tests/docker_backend.rs
+++ b/crates/container/tests/docker_backend.rs
@@ -3,6 +3,7 @@
 //! `test_utils::backend_suite` — shared with the worker fleet backend, which
 //! must satisfy the identical contract (spec §3.1).
 
+use container::ContainerBackend;
 use container::docker::DockerBackend;
 use test_utils::backend_suite as suite;
 
@@ -43,7 +44,7 @@ async fn inspect_kill_and_not_found() {
 #[tokio::test]
 async fn remove_reclaims_exited_container_and_is_idempotent() {
     let Some(be) = docker() else { return };
-    let id = be.launch(cfg("exit 0")).await.unwrap();
+    let id = be.launch(suite::cfg("exit 0")).await.unwrap();
     assert_eq!(be.wait(&id).await.unwrap(), 0);
 
     // While exited-but-present it is a sweep candidate.

--- a/crates/store/src/worker.rs
+++ b/crates/store/src/worker.rs
@@ -5,8 +5,8 @@
 use crate::{NatsStore, StoreError, subjects};
 use std::time::Duration;
 use types::worker::{
-    ContainerRef, CopyFileOk, CopyFileRequest, InspectOk, LaunchOk, LogsOk, PingOk, WorkerError,
-    WorkerLaunchRequest, WorkerReply,
+    ContainerRef, CopyFileOk, CopyFileRequest, InspectOk, LaunchOk, ListExitedOk, LogsOk, PingOk,
+    WorkerError, WorkerLaunchRequest, WorkerReply,
 };
 
 /// Requests must fit NATS's default 1MB max_payload with headroom. Launch
@@ -128,6 +128,18 @@ impl WorkerRpc {
 
     pub async fn ping(&self) -> std::result::Result<PingOk, WorkerRpcError> {
         self.call("ping", &serde_json::json!({}), PING_TIMEOUT)
+            .await
+    }
+
+    pub async fn remove(&self, id: &str) -> std::result::Result<(), WorkerRpcError> {
+        let _: serde_json::Value = self
+            .call("remove", &ContainerRef { id: id.into() }, OP_TIMEOUT)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn list_exited(&self) -> std::result::Result<ListExitedOk, WorkerRpcError> {
+        self.call("list_exited", &serde_json::json!({}), OP_TIMEOUT)
             .await
     }
 }

--- a/crates/types/src/worker.rs
+++ b/crates/types/src/worker.rs
@@ -120,6 +120,12 @@ pub struct LogsOk {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListExitedOk {
+    /// `{node}/{docker_id}` ids of exited managed containers on the node.
+    pub ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PingOk {
     /// Running `chuggernaut.managed` containers on the node (slot accounting).
     pub running: u32,

--- a/crates/worker/src/backend.rs
+++ b/crates/worker/src/backend.rs
@@ -320,6 +320,34 @@ impl ContainerBackend for FleetBackend {
             }
         }
     }
+
+    async fn remove(&self, id: &ContainerId) -> Result<(), BackendError> {
+        let node = self.route(id)?;
+        match &node.handle {
+            NodeHandle::Docker { backend } => backend.remove(id).await,
+            NodeHandle::Worker { rpc, .. } => {
+                rpc.remove(id).await.map_err(|e| rpc_err(Some(id), e))
+            }
+        }
+    }
+
+    async fn list_managed_exited(&self) -> Result<Vec<ContainerId>, BackendError> {
+        let mut ids = Vec::new();
+        for node in &self.nodes {
+            match &node.handle {
+                NodeHandle::Docker { backend } => ids.extend(backend.list_managed_exited().await?),
+                NodeHandle::Worker { rpc, .. } => match rpc.list_exited().await {
+                    Ok(ok) => ids.extend(ok.ids),
+                    // An unreachable worker must not fail the whole sweep —
+                    // its exited containers get reclaimed on a later pass.
+                    Err(e) => {
+                        tracing::warn!(node = %node.name, "list_exited skipped: {e}");
+                    }
+                },
+            }
+        }
+        Ok(ids)
+    }
 }
 
 /// Convenience for `run.rs`: does this fleet contain any worker nodes?

--- a/crates/worker/src/daemon.rs
+++ b/crates/worker/src/daemon.rs
@@ -149,6 +149,8 @@ async fn handle(state: &WorkerState, subject: &str, payload: &[u8]) -> Vec<u8> {
         Some("copy_file") => encode_reply(&copy_file(state, payload).await),
         Some("logs") => encode_reply(&logs(state, payload).await),
         Some("ping") => encode_reply(&ping(state).await),
+        Some("remove") => encode_reply(&remove(state, payload).await),
+        Some("list_exited") => encode_reply(&list_exited(state).await),
         other => encode_reply::<()>(&WorkerReply::Err {
             error: WorkerError::Other {
                 message: format!("unknown op {other:?} on {subject}"),
@@ -283,6 +285,31 @@ async fn logs(state: &WorkerState, payload: &[u8]) -> WorkerReply<LogsOk> {
                 data_b64: b64_encode(&data),
                 truncated,
             })
+        }
+        .await,
+    )
+}
+
+async fn remove(state: &WorkerState, payload: &[u8]) -> WorkerReply<serde_json::Value> {
+    reply(
+        async {
+            let req: ContainerRef = parse(payload)?;
+            state.backend.remove(&req.id).await.map_err(backend_err)?;
+            Ok(serde_json::json!({}))
+        }
+        .await,
+    )
+}
+
+async fn list_exited(state: &WorkerState) -> WorkerReply<types::worker::ListExitedOk> {
+    reply(
+        async {
+            let ids = state
+                .backend
+                .list_managed_exited()
+                .await
+                .map_err(backend_err)?;
+            Ok(types::worker::ListExitedOk { ids })
         }
         .await,
     )

--- a/crates/worker/tests/nats_backend.rs
+++ b/crates/worker/tests/nats_backend.rs
@@ -138,6 +138,25 @@ async fn local_artifact_substitution_and_unknown_artifact() {
 }
 
 #[tokio::test]
+async fn remove_and_exited_sweep_through_the_proxy() {
+    let server = require_nats!();
+    let Some((fleet, daemon)) = setup(&server, b"#!/bin/sh\nexit 0\n").await else {
+        return;
+    };
+    let id = fleet.launch(suite::cfg("exit 0")).await.unwrap();
+    assert_eq!(fleet.wait(&id).await.unwrap(), 0);
+    assert!(
+        fleet.list_managed_exited().await.unwrap().contains(&id),
+        "exited container visible to the sweep through the proxy"
+    );
+    fleet.remove(&id).await.unwrap();
+    assert!(!fleet.list_managed_exited().await.unwrap().contains(&id));
+    // Idempotent, like the direct backend.
+    fleet.remove(&id).await.unwrap();
+    daemon.abort();
+}
+
+#[tokio::test]
 async fn out_of_service_worker_fails_placement_not_startup() {
     let server = require_nats!();
     // No daemon at all: startup succeeds (soft-fail), launch reports no slots.


### PR DESCRIPTION
Release 3's deploy failed because two lineages merged without ever being compiled together: #10 grew the ContainerBackend trait (container cleanup) on integration while #44 added FleetBackend on main; the merge commit was the first combined tree. This implements the new ops across the worker wire protocol + daemon + FleetBackend, with proxy-path contract tests, and fixes #10's test imports (same cause). `./tasks/ci.sh` green locally including live NATS/Docker tiers.

Structural note: this failure mode dies with the ownership flip (platform-owned single main; every change through one merge queue) — which is the next thing we do after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)